### PR TITLE
[codex] fix concerts auth and my concerts flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ FIREBASE_PROJECT_ID=
 FIREBASE_CLIENT_EMAIL=
 # Use a single-line key with \n for line breaks
 FIREBASE_PRIVATE_KEY=
+# Legacy fallback supported in code only for older local env files:
+# FIREBASE_PRIVATE_KEY_ID=
 
 # GitHub MCP auth
 GITHUB_TOKEN=

--- a/client/src/components/MyConcerts.vue
+++ b/client/src/components/MyConcerts.vue
@@ -1,12 +1,113 @@
 <template>
   <div class="my-concerts-container">
     <h2>My Concerts</h2>
-    <p>Your upcoming concerts will be displayed here.</p>
+
+    <p v-if="loading" class="state-text">Loading your concerts...</p>
+    <p v-else-if="error" class="state-text state-text--error">{{ error }}</p>
+
+    <div v-else-if="concerts.length" class="concert-list">
+      <article v-for="concert in concerts" :key="concert.id" class="concert-card">
+        <div class="concert-card__header">
+          <h3>{{ concert.title }}</h3>
+          <span class="genre-chip">{{ concert.genre }}</span>
+        </div>
+        <p class="concert-meta">{{ formatDate(concert.startsAt) }}</p>
+        <p class="concert-meta">{{ formatVenue(concert.venues) }}</p>
+        <p v-if="concert.artists.length" class="concert-meta">
+          {{ formatArtists(concert.artists) }}
+        </p>
+        <p v-if="concert.description" class="concert-description">{{ concert.description }}</p>
+      </article>
+    </div>
+
+    <p v-else class="state-text">
+      No concerts yet. Once you add one, it will show up here after you log in.
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
-// No script needed for this placeholder component yet
+import { ref, watch } from 'vue';
+import { useAuth } from '../composables/useAuth';
+import { fetchUserConcerts } from '../composables/useApi';
+
+interface ConcertVenue {
+  name: string;
+  city?: string;
+  state?: string;
+  country?: string;
+}
+
+interface ConcertArtist {
+  name: string;
+  role?: string;
+  genre?: string;
+}
+
+interface ConcertItem {
+  id: string;
+  title: string;
+  genre: string;
+  startsAt: string;
+  endsAt?: string | null;
+  venues: ConcertVenue[];
+  artists: ConcertArtist[];
+  description?: string | null;
+}
+
+const { user } = useAuth();
+
+const concerts = ref<ConcertItem[]>([]);
+const loading = ref(false);
+const error = ref('');
+
+const loadConcerts = async () => {
+  if (!user.value) {
+    concerts.value = [];
+    error.value = '';
+    loading.value = false;
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+
+  try {
+    const token = await user.value.getIdToken();
+    const response = await fetchUserConcerts(token);
+    concerts.value = Array.isArray(response?.data) ? response.data : [];
+  } catch {
+    error.value = 'Unable to load your concerts right now.';
+  } finally {
+    loading.value = false;
+  }
+};
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value));
+
+const formatVenue = (venues: ConcertVenue[]) => {
+  const primaryVenue = venues[0];
+  if (!primaryVenue) {
+    return 'Venue TBD';
+  }
+
+  const location = [primaryVenue.city, primaryVenue.state].filter(Boolean).join(', ');
+  return location ? `${primaryVenue.name} • ${location}` : primaryVenue.name;
+};
+
+const formatArtists = (artists: ConcertArtist[]) =>
+  artists.slice(0, 3).map((artist) => artist.name).join(', ');
+
+watch(user, () => {
+  void loadConcerts();
+}, { immediate: true });
 </script>
 
 <style scoped>
@@ -16,5 +117,55 @@
   background-color: var(--card-bg);
   border-radius: 0.75rem;
   border: 1px solid var(--border);
+}
+
+.concert-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.concert-card {
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--background);
+}
+
+.concert-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.concert-card__header h3 {
+  margin: 0;
+}
+
+.genre-chip {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: var(--secondary-bg);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+.concert-meta {
+  margin: 0.5rem 0 0;
+  color: var(--text-light);
+}
+
+.concert-description {
+  margin: 0.75rem 0 0;
+}
+
+.state-text {
+  margin-top: 1rem;
+  color: var(--text-light);
+}
+
+.state-text--error {
+  color: #b42318;
 }
 </style>

--- a/client/src/composables/useApi.ts
+++ b/client/src/composables/useApi.ts
@@ -40,3 +40,17 @@ export async function updateUserProfile(
     throw error;
   }
 }
+
+export async function fetchUserConcerts(token: string) {
+  try {
+    const response = await apiClient.get('/concerts', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching user concerts:', error);
+    throw error;
+  }
+}

--- a/client/src/composables/useAuth.ts
+++ b/client/src/composables/useAuth.ts
@@ -22,29 +22,30 @@ const auth = getAuth();
 // A flag to prevent duplicate sync calls
 let isSyncing = false;
 
+onAuthStateChanged(auth, async (firebaseUser) => {
+  user.value = firebaseUser;
+
+  if (firebaseUser && !isSyncing) {
+    isSyncing = true;
+    try {
+      const token = await firebaseUser.getIdToken();
+      await syncUserToBackend(token);
+    } catch (error) {
+      console.error('Failed to sync user on auth change:', error);
+    } finally {
+      isSyncing = false;
+    }
+  }
+});
+
 /**
  * A reactive composable to manage user authentication state and actions.
  */
 export function useAuth() {
-  onAuthStateChanged(auth, async (firebaseUser) => {
-    user.value = firebaseUser;
-    
-    if (firebaseUser && !isSyncing) {
-      isSyncing = true;
-      try {
-        const token = await firebaseUser.getIdToken();
-        await syncUserToBackend(token);
-      } catch (error) {
-        console.error('Failed to sync user on auth change:', error);
-      } finally {
-        isSyncing = false;
-      }
-    }
-  });
-
   const signInWithGoogle = async () => {
     try {
       await signInWithPopup(auth, googleProvider);
+      await router.push('/');
     } catch (error) {
       console.error("Error signing in with Google:", error);
     }
@@ -53,6 +54,7 @@ export function useAuth() {
   const signUpWithEmail = async (email: string, password: string) => {
     try {
       await createUserWithEmailAndPassword(auth, email, password);
+      await router.push('/');
     } catch (error: any) {
       console.error("Error signing up with email:", error);
       alert(`Error: ${error.message}`);
@@ -62,6 +64,7 @@ export function useAuth() {
   const signInWithEmail = async (email: string, password: string) => {
     try {
       await signInWithEmailAndPassword(auth, email, password);
+      await router.push('/');
     } catch (error: any) {
       console.error("Error signing in with email:", error);
       alert(`Error: ${error.message}`);

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -33,6 +33,11 @@ router.beforeEach((to, _from, next) => {
   const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
   const isAuthenticated = getAuth().currentUser;
 
+  if (to.path === '/login' && isAuthenticated) {
+    next('/');
+    return;
+  }
+
   if (requiresAuth && !isAuthenticated) {
     next('/login');
   } else {

--- a/src/apis/concerts/concert.service.ts
+++ b/src/apis/concerts/concert.service.ts
@@ -35,19 +35,19 @@ export class ConcertService {
     }
 
     if (query.startsAfter) {
-      qb.andWhere('concert.starts_at >= :startsAfter', {
+      qb.andWhere('concert.startsAt >= :startsAfter', {
         startsAfter: query.startsAfter,
       });
     }
 
     if (query.startsBefore) {
-      qb.andWhere('concert.starts_at <= :startsBefore', {
+      qb.andWhere('concert.startsAt <= :startsBefore', {
         startsBefore: query.startsBefore,
       });
     }
 
     const [data, total] = await qb
-      .orderBy('concert.starts_at', 'ASC')
+      .orderBy('concert.startsAt', 'ASC')
       .skip((page - 1) * pageSize)
       .take(pageSize)
       .getManyAndCount();

--- a/src/apis/concerts/entities/concert.entity.ts
+++ b/src/apis/concerts/entities/concert.entity.ts
@@ -29,10 +29,10 @@ export class Concert {
   @Column({ type: 'varchar', length: 120 })
   genre: string;
 
-  @Column({ type: 'timestamptz' })
+  @Column({ name: 'starts_at', type: 'timestamptz' })
   startsAt: Date;
 
-  @Column({ type: 'timestamptz', nullable: true })
+  @Column({ name: 'ends_at', type: 'timestamptz', nullable: true })
   endsAt?: Date | null;
 
   @Column({ type: 'jsonb', default: () => "'[]'::jsonb" })
@@ -44,9 +44,9 @@ export class Concert {
   @Column({ type: 'text', nullable: true })
   description?: string | null;
 
-  @CreateDateColumn({ type: 'timestamptz' })
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt: Date;
 
-  @UpdateDateColumn({ type: 'timestamptz' })
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
   updatedAt: Date;
 }

--- a/src/docs/WORKFLOW_PLAN.md
+++ b/src/docs/WORKFLOW_PLAN.md
@@ -1,148 +1,155 @@
-# Onboarding Flow Plan
+# EZ Vibes Workflow Plan
 
-## Learning Objectives
-- Who is responsible for what ( swim lanes)
+## Product Loop
 
-## Tools used
-- draw
-- firebase auth
-- vs code or goose
+EZ Vibes should be built around one core loop:
 
-## Additonal resources too learn
-- draw.io
-- firebase auth
-- firestore
-- postgress
+1. Event content is uploaded or submitted.
+2. The ingestion engine extracts structured signals from posters, flyers, and form submissions.
+3. The system normalizes that data into canonical event, venue, and artist records.
+4. Admins review low-confidence or duplicate-prone records.
+5. Approved events are published into the discovery catalog.
+6. Fans discover events through city-, region-, and preference-aware feeds.
+7. Partners consume visibility, leads, and event intelligence through APIs and dashboards.
 
-# Workflow PLan
+If a feature does not strengthen this loop, it should not be in the MVP.
 
-## Authentication & User Bootstrap Flow
+## Pillars
 
-### Status
+### 1. AI Ingestion Engine
 
-**Finalized (MVP v1)** – aligned with current architecture diagram and implementation plan.
+- Accept image uploads, PDFs, and structured event submissions
+- Store raw assets in Google Cloud Storage
+- Run OCR with Google Vision
+- Parse dates, times, venue names, artists, cities, and genres
+- Assign confidence scores and flag records for review
 
----
+### 2. Structured Event Catalog
 
-## Summary
+- Normalize events into relational entities
+- Prevent obvious duplicates across repeated flyers and submissions
+- Preserve source provenance and ingestion history
+- Support approval states before records become public
 
-This document describes the finalized **authentication and user bootstrap flow** for the Carolina Live Music ecosystem, powered by the open‑source **NIDO API**.
+### 3. Personalized Recommendation Engine
 
-The architecture is intentionally designed to:
+- Start with rules, not ML
+- Rank by city, region, saved preferences, timing, and recency
+- Return useful feeds for Raleigh/Triangle, Wilmington, Charlotte, Asheville, and Greensboro/Triad
 
-- Use **Firebase Authentication** for identity and OAuth abstraction
-- Keep the **backend (NIDO API)** authoritative for domain users
-- Minimize database footprint for the MVP
-- Support web, mobile, and future AI/agent clients with the same flow
+### 4. Partner Platform Layer
 
-This design is production‑sound while remaining cost‑effective and simple for early development.
+- Expose approved event data via partner-friendly APIs
+- Support partner-specific submissions and visibility workflows
+- Make venue/promoter value legible through speed, accuracy, and reach
 
----
+## User Groups
 
-## Core Design Principles
+### Consumers
 
-- **Identity ≠ Domain User**
-- **Clients are thin** (no business logic)
-- **Backend is deterministic**
-- **Auth is reusable across human and AI clients**
+- Discover upcoming live music by city and date
+- Save preferences and favorite events
+- View reliable event details sourced from real local signals
 
----
+### Venues
 
-## High-Level Components
+- Submit events quickly
+- Ensure listings are accurate and timely
+- Increase discovery in local feeds
 
-### Web App
+### Festival and Promoter Partners
 
-- Vue 3 + TypeScript
-- Uses Firebase Client SDK
-- Stores Firebase JWT in memory or secure client storage
-- Makes authenticated HTTP requests via Axios
+- Submit batches or partner-managed events
+- Access structured event records through APIs
+- Use EZ Vibes as a regional event intelligence layer
 
-### Identity Providers
+### Internal Admins and Curators
 
-- **Google Identity Platform** (OAuth)
-- **Firebase Authentication** (token verification + JWT issuance)
+- Review OCR output and parser decisions
+- Resolve duplicates
+- Approve, reject, or edit normalized records
+- Monitor ingestion job quality
 
-### Backend API
+## MVP Definition
 
-- **NIDO API (NestJS)**
-- Validates Firebase JWTs using Firebase Admin SDK
-- Owns domain user lifecycle
-- Exposes idempotent auth bootstrap endpoint (`POST /auth/sync`). This endpoint's job is to find a user based on the token, create one if they don't exist, and return the canonical user entity from Postgres.
+The MVP is successful when EZ Vibes can demonstrate this live:
 
-### Data Store
+- A flyer or poster is uploaded
+- OCR and parsing produce a draft event
+- An admin reviews and approves it
+- The approved event appears in a fan-facing discovery feed
+- A partner can retrieve that event through an API
 
-- **Postgres** (domain users only)
-- Firebase Auth stores identity metadata
+### In Scope
 
----
+- Image upload to Google Cloud Storage
+- OCR via Google Vision
+- Parsing pipeline for basic event fields
+- Human review queue
+- Approved event catalog
+- Consumer discovery feed by city/date
+- Simple personalization using city, region, genre, and timing
+- Partner API for approved events
 
-## Detailed User Signup Flow
+### Out of Scope
 
-(Based on the diagram in `src/assets/FirebaseSignupFlow.jpg`)
+- Fully automated publishing with no review
+- Complex recommendation models
+- Ticketing integrations
+- Social graph features
+- Full self-serve venue analytics portal
+- Multi-state expansion
 
-This flow outlines the precise sequence of events when a new user signs up.
+## Operating Rules
 
-### Swim Lanes
-- **Web App:** The client-side application the user interacts with.
-- **Identity Providers:** Google Identity and Firebase Authentication.
-- **Nido API:** The backend application.
-- **Data Store:** The Postgres database.
+### Data Quality Rule
 
-### Step-by-step Flow
-1.  **Web App:** User arrives on the Sign Up page.
-2.  **Web App:** User clicks "Sign Up with Google".
-3.  **Identity Providers:** The client redirects the user to Google Identity Platform for OAuth.
-4.  **Identity Providers:** Google authenticates the user and returns a Google ID Token.
-5.  **Identity Providers:** The Google ID Token is exchanged for a Firebase JWT.
-6.  **Web App:** The frontend receives the Firebase JWT and stores it in memory or secure storage.
-7.  **Web App & Nido API:** The frontend calls a `POST /auth/sync` endpoint on the Nido API, including the Firebase JWT in the authorization header.
-8.  **NIDO API:** The API validates the Firebase JWT using the Firebase Admin SDK. It then checks if a user record already exists in the database.
-9.  **NIDO API & Data Store:** If no user record is found, a new one is created in the Postgres database. The user's `email`, `picture`, and `uid` (Firebase ID) are extracted from the decoded JWT claims and mapped to the new user record.
-10. **NIDO API:** The user object (either found or newly created) is returned to the frontend.
-11. **Web App:** The user sees an "account created" confirmation and a welcome message.
+No OCR result should become publicly visible without either:
 
----
+- high-confidence auto-approval rules, or
+- admin review
 
-## Core Implemented Patterns
+For MVP, prefer manual review over risky automation.
 
-### @CurrentUser Decorator
+### Source-of-Truth Rule
 
-To streamline development and avoid repetitive database queries, a custom NestJS decorator, `@CurrentUser()`, has been implemented. This allows easy access to the fully populated Postgres `User` entity within any controller method.
+- Raw assets live in GCS
+- Extracted text and parsing artifacts belong to ingestion jobs
+- Canonical public records live in normalized relational tables
 
-**Example Usage:**
-```typescript
-@Get('profile')
-getProfile(@CurrentUser() user: UserEntity) {
-  // 'user' is the full UserEntity object from Postgres
-  return user;
-}
-```
+### Domain Boundary Rule
 
----
+- `events`, `venues`, and `artists` are the canonical catalog domains
+- The existing `concerts` module is a user-scoped experience layer for "My Concerts", not the long-term catalog source of truth
+- New ingestion, moderation, partner, and discovery work should publish into canonical `events` rather than extending owner-scoped `concerts`
+- `concerts` can continue to support the logged-in user experience until the canonical catalog is ready to power that view directly
 
-## User Profile Management
+### Recommendation Rule
 
-### Status: Implemented (MVP v1)
+For MVP, recommendations are deterministic and explainable:
 
-A basic user profile page has been created to allow users to manage their data.
+- city match
+- nearby region boost
+- genre match
+- upcoming-soon boost
+- partner/featured boost if needed
 
-**Flow:**
-1.  **Web App:** After logging in, the user navigates to the `/profile` page.
-2.  **Web App:** The frontend uses the stored user state to display current information.
-3.  **Web App:** The user updates their name in an input field.
-4.  **Web App & Nido API:** On submission, the client sends a `PATCH /user` request with the updated name.
-5.  **NIDO API:** The backend receives the request, validates it, and updates the `name` field for the corresponding user in the Postgres database.
+## Immediate Build Order
 
----
+1. Ingestion pipeline skeleton
+2. Normalized schema
+3. Admin moderation workflow
+4. Public event catalog API
+5. Consumer discovery feed
+6. Partner API access
+7. Rules-based personalization
 
-## Next Steps: Concerts Feature
+## Decision Filters
 
-### Status: Planned
+Before implementing new work, confirm:
 
-The next major feature is to display a list of concerts relevant to the user on the homepage after they have logged in.
-
-**High-Level Plan:**
-1.  **Frontend:** Build out the `MyConcerts.vue` component to be a container for a list of concert cards.
-2.  **Backend:** Create a new module for Concerts (`/concerts`) with a controller, service, and entity.
-3.  **Backend:** Implement a `GET /concerts` endpoint that retrieves a list of concerts for the currently authenticated user.
-4.  **Frontend:** Update the `HomePage.vue` to call the `GET /concerts` endpoint and pass the data to the `MyConcerts.vue` component for rendering.
+- Does it improve ingestion accuracy?
+- Does it improve event normalization quality?
+- Does it improve discovery usefulness?
+- Does it improve partner value?
+- Can it be demonstrated in the MVP story?

--- a/src/firebase/firebase.service.spec.ts
+++ b/src/firebase/firebase.service.spec.ts
@@ -3,8 +3,10 @@ import { FirebaseService } from './firebase.service';
 
 describe('FirebaseService', () => {
   let service: FirebaseService;
+  const originalEnv = { ...process.env };
 
   beforeEach(async () => {
+    process.env = { ...originalEnv };
     const module: TestingModule = await Test.createTestingModule({
       providers: [FirebaseService],
     }).compile();
@@ -14,5 +16,21 @@ describe('FirebaseService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('resolves FIREBASE_PRIVATE_KEY when present', () => {
+    process.env.FIREBASE_PRIVATE_KEY = 'line1\\nline2';
+    expect((service as any).resolvePrivateKey()).toBe('line1\nline2');
+  });
+
+  it('falls back to legacy FIREBASE_PRIVATE_KEY_ID when it contains a PEM key', () => {
+    process.env.FIREBASE_PRIVATE_KEY = '';
+    process.env.FIREBASE_PRIVATE_KEY_ID = '-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n';
+
+    expect((service as any).resolvePrivateKey()).toContain('BEGIN PRIVATE KEY');
   });
 });

--- a/src/firebase/firebase.service.ts
+++ b/src/firebase/firebase.service.ts
@@ -7,6 +7,20 @@ import { Auth, getAuth } from 'firebase-admin/auth';
 export class FirebaseService implements OnModuleInit {
   private firebaseApp: App;
 
+  private resolvePrivateKey() {
+    const directPrivateKey = process.env.FIREBASE_PRIVATE_KEY;
+    if (directPrivateKey) {
+      return directPrivateKey.replace(/\\n/g, '\n');
+    }
+
+    const legacyPrivateKey = process.env.FIREBASE_PRIVATE_KEY_ID;
+    if (legacyPrivateKey?.includes('BEGIN PRIVATE KEY')) {
+      return legacyPrivateKey.replace(/\\n/g, '\n');
+    }
+
+    return undefined;
+  }
+
   onModuleInit() {
     // To connect to your Firebase project, you need a Service Account.
     // 1. Go to your Firebase project console > Project Settings > Service accounts.
@@ -19,8 +33,8 @@ export class FirebaseService implements OnModuleInit {
       projectId: process.env.FIREBASE_PROJECT_ID,
       clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
       // The private key can be tricky with .env files due to line breaks.
-      // A common practice is to base64 encode the key or replace '\n' with '\\n'.
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      // A common practice is to replace '\n' with '\\n' in the env value.
+      privateKey: this.resolvePrivateKey(),
     };
 
     if (


### PR DESCRIPTION
## Summary
- fix Firebase admin bootstrap so authenticated backend routes accept the current local/private key env shape
- fix the concerts entity/query mapping so authenticated `GET /concerts` no longer fails on column name mismatches
- wire the client My Concerts view to the authenticated concerts API and clean up duplicate auth-flow redirects/listeners
- document the current domain direction for canonical `events` vs temporary user-scoped `concerts`

## Why
The logged-in My Concerts flow was broken in two layers:
- backend auth-protected routes were rejecting valid tokens because Firebase admin was not initializing from the current env shape
- after auth was fixed, the concerts query still failed because the entity/query mapping did not match the existing snake_case database columns

This branch fixes the authenticated concerts path end to end and tightens the client auth flow so the signed-in landing experience is more coherent.

## Validation
- `npm test -- firebase.service.spec.ts --runInBand`
- `npm run build`
- `npm run build --prefix client`
- verified that the auth failure moved from `401` to a query-layer `500`, then patched the column mapping issue

## Notes
- this branch also includes the current My Concerts UI wiring and a workflow-plan doc update that clarifies `concerts` as a temporary user-scoped surface versus canonical `events`
- I did not run a full browser sign-in/sign-out matrix or API e2e suite in this step
