### PR TITLE
[codex] add events demo calendar view

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
 import { useAuth } from './composables/useAuth';
+import { routeLoading } from './stores/routeLoading';
 
 const { user, signOut } = useAuth();
 </script>
 
 <template>
   <div id="app-layout">
+    <transition name="route-fade">
+      <div v-if="routeLoading" class="route-loading">
+        <div class="route-loading__dot"></div>
+      </div>
+    </transition>
     <header class="header">
       <div class="container">
-        <router-link to="/" class="logo-link"><h1 class="logo">Ez Vibes</h1></router-link>
+        <router-link to="/" class="logo-link"><h1 class="logo">EZ Vibes</h1></router-link>
         <nav v-if="user">
           <span class="user-email">{{ user.email }}</span>
+          <router-link to="/events" class="nav-link">Events</router-link>
           <router-link to="/profile" class="nav-link">Profile</router-link>
           <a href="#" @click.prevent="signOut" class="nav-link">Sign Out</a>
         </nav>
@@ -102,5 +109,48 @@ nav a.router-link-exact-active {
 /* Main Content Area */
 .main-content {
   padding: 4rem 0;
+}
+
+.route-loading {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: grid;
+  place-items: center;
+  background: rgba(244, 246, 244, 0.72);
+  backdrop-filter: blur(3px);
+}
+
+.route-loading__dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--primary);
+  animation: route-pulse 0.85s ease-in-out infinite;
+}
+
+@keyframes route-pulse {
+  0% {
+    transform: scale(0.7);
+    opacity: 0.55;
+  }
+  70% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.7);
+    opacity: 0.55;
+  }
+}
+
+.route-fade-enter-active,
+.route-fade-leave-active {
+  transition: opacity 0.18s ease;
+}
+
+.route-fade-enter-from,
+.route-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/client/src/components/MyConcerts.vue
+++ b/client/src/components/MyConcerts.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useAuth } from '../composables/useAuth';
 import { fetchUserConcerts } from '../composables/useApi';
 
@@ -105,9 +105,21 @@ const formatVenue = (venues: ConcertVenue[]) => {
 const formatArtists = (artists: ConcertArtist[]) =>
   artists.slice(0, 3).map((artist) => artist.name).join(', ');
 
+const handleConcertsChanged = () => {
+  void loadConcerts();
+};
+
 watch(user, () => {
   void loadConcerts();
 }, { immediate: true });
+
+onMounted(() => {
+  window.addEventListener('concerts:changed', handleConcertsChanged);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('concerts:changed', handleConcertsChanged);
+});
 </script>
 
 <style scoped>

--- a/client/src/components/events/EventCard.vue
+++ b/client/src/components/events/EventCard.vue
@@ -1,0 +1,134 @@
+<template>
+  <article class="event-card">
+    <div class="event-card__poster">
+      <img :src="event.posterUrl" :alt="`${event.title} poster`" loading="lazy" />
+    </div>
+
+    <div class="event-card__body">
+      <h3 class="event-card__title">{{ event.title }}</h3>
+      <p class="event-card__venue">{{ primaryVenueName }}</p>
+      <p class="event-card__location">{{ locationLabel }}</p>
+      <p class="event-card__time">{{ formattedStartTime }}</p>
+
+      <p v-if="event.description" class="event-card__description">{{ event.description }}</p>
+
+      <button class="event-card__tickets" type="button" disabled>Tickets</button>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { EventListItem } from '../../types/events';
+
+const props = defineProps<{
+  event: EventListItem;
+}>();
+
+const primaryVenue = computed(() => props.event.venues[0]);
+
+const primaryVenueName = computed(() => primaryVenue.value?.name ?? 'Venue TBD');
+
+const locationLabel = computed(() => {
+  if (!primaryVenue.value) {
+    return 'Location TBD';
+  }
+
+  const pieces = [primaryVenue.value.city, primaryVenue.value.state].filter(Boolean);
+  return pieces.length ? pieces.join(', ') : 'Location TBD';
+});
+
+const formattedStartTime = computed(() =>
+  new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(props.event.startsAt))
+);
+</script>
+
+<style scoped>
+.event-card {
+  display: grid;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 14px 30px rgba(31, 41, 55, 0.08);
+}
+
+.event-card__poster {
+  background: #dfe6dc;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.event-card__poster img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.event-card__body {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+.event-card__title,
+.event-card__venue,
+.event-card__location,
+.event-card__time,
+.event-card__description {
+  margin: 0;
+}
+
+.event-card__title {
+  font-size: 1.2rem;
+  line-height: 1.2;
+}
+
+.event-card__venue,
+.event-card__time {
+  font-weight: 600;
+}
+
+.event-card__location,
+.event-card__description {
+  color: var(--text-light);
+}
+
+.event-card__tickets {
+  justify-self: start;
+  margin-top: 0.35rem;
+  padding: 0.6rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-light);
+  cursor: not-allowed;
+  font-weight: 600;
+}
+
+@media (min-width: 720px) {
+  .event-card {
+    grid-template-columns: 220px 1fr;
+  }
+
+  .event-card__poster {
+    aspect-ratio: auto;
+    min-height: 100%;
+  }
+
+  .event-card__body {
+    padding: 1.2rem;
+  }
+
+  .event-card__title {
+    font-size: 1.35rem;
+  }
+}
+</style>

--- a/client/src/components/events/EventFiltersBar.vue
+++ b/client/src/components/events/EventFiltersBar.vue
@@ -1,0 +1,108 @@
+<template>
+  <section class="filters-bar" aria-label="Event filters">
+    <label class="filters-bar__field filters-bar__field--search">
+      <span class="filters-bar__label">Search</span>
+      <input
+        :value="searchText"
+        type="search"
+        placeholder="Search city, band, venue, or genre"
+        @input="onSearchInput"
+      />
+    </label>
+
+    <label class="filters-bar__field">
+      <span class="filters-bar__label">Date Range</span>
+      <select :value="dateRange" @change="onDateRangeChange">
+        <option value="7">Next 7 days</option>
+        <option value="30">Next 30 days</option>
+        <option value="all">All upcoming</option>
+      </select>
+    </label>
+
+    <label class="filters-bar__field">
+      <span class="filters-bar__label">Sort</span>
+      <select :value="sort" @change="onSortChange">
+        <option value="soonest">Soonest</option>
+        <option value="featured">Featured</option>
+      </select>
+    </label>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { DateRangeOption, SortOption } from '../../composables/useEventFilters';
+
+defineProps<{
+  searchText: string;
+  dateRange: DateRangeOption;
+  sort: SortOption;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:searchText', value: string): void;
+  (event: 'update:dateRange', value: DateRangeOption): void;
+  (event: 'update:sort', value: SortOption): void;
+}>();
+
+const onSearchInput = (event: Event) => {
+  emit('update:searchText', (event.target as HTMLInputElement).value);
+};
+
+const onDateRangeChange = (event: Event) => {
+  emit('update:dateRange', (event.target as HTMLSelectElement).value as DateRangeOption);
+};
+
+const onSortChange = (event: Event) => {
+  emit('update:sort', (event.target as HTMLSelectElement).value as SortOption);
+};
+</script>
+
+<style scoped>
+.filters-bar {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 14px 32px rgba(31, 41, 55, 0.06);
+}
+
+.filters-bar__field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.filters-bar__label {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.filters-bar input,
+.filters-bar select {
+  width: 100%;
+  min-width: 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.7rem;
+  border: 1px solid var(--border);
+  background: white;
+  font-size: 0.95rem;
+  color: var(--text-dark);
+  box-sizing: border-box;
+}
+
+.filters-bar input:focus,
+.filters-bar select:focus {
+  outline: 2px solid rgba(58, 79, 57, 0.14);
+  border-color: var(--primary);
+}
+
+@media (min-width: 760px) {
+  .filters-bar {
+    grid-template-columns: minmax(0, 1.8fr) minmax(180px, 0.8fr) minmax(180px, 0.8fr);
+    align-items: end;
+  }
+}
+</style>

--- a/client/src/composables/useApi.ts
+++ b/client/src/composables/useApi.ts
@@ -54,3 +54,36 @@ export async function fetchUserConcerts(token: string) {
     throw error;
   }
 }
+
+export interface CreateConcertPayload {
+  title: string;
+  genre: string;
+  startsAt: string;
+  endsAt?: string;
+  venues: Array<{
+    name: string;
+    city?: string;
+    state?: string;
+    country?: string;
+  }>;
+  artists: Array<{
+    name: string;
+    role?: string;
+    genre?: string;
+  }>;
+  description?: string;
+}
+
+export async function createConcert(token: string, payload: CreateConcertPayload) {
+  try {
+    const response = await apiClient.post('/concerts', payload, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error creating concert:', error);
+    throw error;
+  }
+}

--- a/client/src/composables/useEventFilters.ts
+++ b/client/src/composables/useEventFilters.ts
@@ -1,0 +1,76 @@
+import { computed, ref, unref, type Ref } from 'vue';
+import type { EventListItem } from '../types/events';
+
+export type DateRangeOption = '7' | '30' | 'all';
+export type SortOption = 'soonest' | 'featured';
+
+export function useEventFilters(events: EventListItem[] | Ref<EventListItem[]>) {
+  const searchText = ref('');
+  const dateRange = ref<DateRangeOption>('30');
+  const sort = ref<SortOption>('soonest');
+
+  const filteredEvents = computed(() => {
+    const sourceEvents = unref(events);
+    const now = Date.now();
+    let result = sourceEvents.filter((event) => new Date(event.startsAt).getTime() >= now);
+
+    if (dateRange.value !== 'all') {
+      const days = Number.parseInt(dateRange.value, 10);
+      const maxTime = now + days * 24 * 60 * 60 * 1000;
+      result = result.filter((event) => new Date(event.startsAt).getTime() <= maxTime);
+    }
+
+    const search = searchText.value.trim().toLowerCase();
+    if (search) {
+      const tokens = search.split(/\s+/).filter(Boolean);
+
+      result = result.filter((event) => {
+        const haystack = [
+          event.title,
+          event.genre,
+          event.description ?? '',
+          event.sourceLabel,
+          ...event.displayTags,
+          ...event.artists.map((artist) => artist.name),
+          ...event.venues.flatMap((venue) => [
+            venue.name,
+            venue.city ?? '',
+            venue.state ?? '',
+          ]),
+        ]
+          .join(' ')
+          .toLowerCase();
+
+        return tokens.every((token) => haystack.includes(token));
+      });
+    }
+
+    if (sort.value === 'featured') {
+      return [...result].sort((a, b) => {
+        if (b.demoRank !== a.demoRank) {
+          return b.demoRank - a.demoRank;
+        }
+
+        return new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime();
+      });
+    }
+
+    return [...result].sort(
+      (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime()
+    );
+  });
+
+  const clearFilters = () => {
+    searchText.value = '';
+    dateRange.value = '30';
+    sort.value = 'soonest';
+  };
+
+  return {
+    searchText,
+    dateRange,
+    sort,
+    filteredEvents,
+    clearFilters,
+  };
+}

--- a/client/src/data/sampleEvents.ts
+++ b/client/src/data/sampleEvents.ts
@@ -1,0 +1,120 @@
+import type { EventListItem } from '../types/events';
+import { mapConcertToEventListItem } from '../types/events';
+
+const daysFromNow = (days: number, hour = 19, minute = 0) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  date.setHours(hour, minute, 0, 0);
+  return date.toISOString();
+};
+
+export const sampleEvents: EventListItem[] = [
+  mapConcertToEventListItem(
+    {
+      id: 'evt-duck',
+      title: 'Duck',
+      genre: 'rock',
+      startsAt: daysFromNow(2, 20, 0),
+      venues: [
+        {
+          name: 'Bowstring Brewyard',
+          city: 'Raleigh',
+          state: 'NC',
+        },
+      ],
+      artists: [{ name: 'Duck', role: 'headliner', genre: 'rock' }],
+      description: 'High-energy local show with a late set and a packed room.',
+    },
+    {
+      posterUrl: 'https://placehold.co/720x900/f2eee5/2f402e?text=Duck',
+      sourceLabel: 'Bowstring Brewyard',
+      displayTags: ['rock', 'local', 'high energy'],
+      demoRank: 10,
+    }
+  ),
+  mapConcertToEventListItem(
+    {
+      id: 'evt-pine-street-groove',
+      title: 'Pine Street Groove',
+      genre: 'jam',
+      startsAt: daysFromNow(4, 19, 30),
+      venues: [{ name: 'The Lincoln Theatre', city: 'Raleigh', state: 'NC' }],
+      artists: [{ name: 'Pine Street Groove', role: 'headliner', genre: 'jam' }],
+      description: 'Big grooves, two sets, and a crowd that wants to stay out late.',
+    },
+    {
+      posterUrl: 'https://placehold.co/720x900/e7efe2/3a4f39?text=Pine+Street+Groove',
+      sourceLabel: 'Venue Flyer',
+      displayTags: ['jam', 'danceable', 'triangle'],
+      demoRank: 9,
+    }
+  ),
+  mapConcertToEventListItem(
+    {
+      id: 'evt-midnight-garden-tour',
+      title: 'Midnight Garden Tour',
+      genre: 'indie',
+      startsAt: daysFromNow(6, 20, 0),
+      venues: [{ name: "Cat's Cradle", city: 'Chapel Hill', state: 'NC' }],
+      artists: [{ name: 'Midnight Garden Tour', role: 'headliner', genre: 'indie' }],
+      description: 'A softer indie night with layered guitars and a strong local opener.',
+    },
+    {
+      posterUrl: 'https://placehold.co/720x900/f7efe7/56403b?text=Midnight+Garden+Tour',
+      sourceLabel: 'Poster Upload',
+      displayTags: ['indie', 'night out', 'carolina'],
+      demoRank: 8,
+    }
+  ),
+  mapConcertToEventListItem(
+    {
+      id: 'evt-carolina-brass-ensemble',
+      title: 'Carolina Brass Ensemble',
+      genre: 'jazz',
+      startsAt: daysFromNow(8, 18, 30),
+      venues: [{ name: 'DPAC', city: 'Durham', state: 'NC' }],
+      artists: [{ name: 'Carolina Brass Ensemble', role: 'headliner', genre: 'jazz' }],
+      description: 'Brass-led jazz with a cleaner seated-room feel.',
+    },
+    {
+      posterUrl: 'https://placehold.co/720x900/e8eef4/2c4157?text=Carolina+Brass',
+      sourceLabel: 'DPAC Listing',
+      displayTags: ['jazz', 'seated', 'durham'],
+      demoRank: 7,
+    }
+  ),
+  mapConcertToEventListItem(
+    {
+      id: 'evt-riverwalk-sessions',
+      title: 'Riverwalk Sessions',
+      genre: 'folk',
+      startsAt: daysFromNow(11, 19, 0),
+      venues: [{ name: 'The Orange Peel', city: 'Asheville', state: 'NC' }],
+      artists: [{ name: 'Riverwalk Sessions', role: 'headliner', genre: 'folk' }],
+      description: 'A quieter acoustic-forward booking with a packed support lineup.',
+    },
+    {
+      posterUrl: 'https://placehold.co/720x900/f0f1e7/49523d?text=Riverwalk+Sessions',
+      sourceLabel: 'Promoter Post',
+      displayTags: ['folk', 'acoustic', 'asheville'],
+      demoRank: 6,
+    }
+  ),
+  mapConcertToEventListItem(
+    {
+      id: 'evt-neon-skyline-night',
+      title: 'Neon Skyline Night',
+      genre: 'electronic',
+      startsAt: daysFromNow(14, 21, 0),
+      venues: [{ name: 'The Fillmore Charlotte', city: 'Charlotte', state: 'NC' }],
+      artists: [{ name: 'Neon Skyline Night', role: 'headliner', genre: 'electronic' }],
+      description: 'A bigger room electronic booking with strong production and a late crowd.',
+    },
+    {
+      posterUrl: 'https://placehold.co/720x900/efe7f4/47335a?text=Neon+Skyline',
+      sourceLabel: 'Promoter Import',
+      displayTags: ['electronic', 'late', 'charlotte'],
+      demoRank: 5,
+    }
+  ),
+];

--- a/client/src/pages/EventsPage.vue
+++ b/client/src/pages/EventsPage.vue
@@ -1,0 +1,463 @@
+<template>
+  <section class="events-page">
+    <header class="events-page__hero">
+      <div class="events-page__hero-copy">
+        <p class="events-page__eyebrow">Demo Discovery Feed</p>
+        <p class="events-page__intro">
+          This demo route previews a browseable event feed using a frontend model that can later
+          map cleanly onto the existing concerts API.
+        </p>
+      </div>
+
+      <button class="events-page__toggle" type="button" @click="toggleAddForm">
+        {{ showAddForm ? 'Close form' : 'Add a show' }}
+      </button>
+    </header>
+
+    <p v-if="pageMessage" :class="pageMessageClass">{{ pageMessage }}</p>
+
+    <section v-if="showAddForm" class="add-show-panel">
+      <div class="add-show-panel__header">
+        <h2>Add a show</h2>
+        <p>Create a concert for your account and preview it here in the demo feed.</p>
+      </div>
+
+      <form class="add-show-panel__form" @submit.prevent="handleSubmit">
+        <label>
+          <span>Title</span>
+          <input v-model="form.title" type="text" placeholder="Artist or lineup name" />
+        </label>
+        <label>
+          <span>Genre</span>
+          <input v-model="form.genre" type="text" placeholder="rock, indie, jazz" />
+        </label>
+        <label>
+          <span>Artist / Lineup</span>
+          <input v-model="form.artistName" type="text" placeholder="Duck" />
+        </label>
+        <label>
+          <span>Venue</span>
+          <input v-model="form.venueName" type="text" placeholder="Venue name" />
+        </label>
+        <label>
+          <span>City</span>
+          <input v-model="form.city" type="text" placeholder="Raleigh" />
+        </label>
+        <label>
+          <span>State</span>
+          <select v-model="form.state">
+            <option value="NC">NC</option>
+            <option value="SC">SC</option>
+          </select>
+        </label>
+        <label>
+          <span>Date</span>
+          <input v-model="form.date" type="date" />
+        </label>
+        <label>
+          <span>Time</span>
+          <input v-model="form.time" type="time" />
+        </label>
+        <label>
+          <span>Poster URL</span>
+          <input v-model="form.posterUrl" type="url" placeholder="https://..." />
+        </label>
+        <label class="add-show-panel__full">
+          <span>Description</span>
+          <textarea
+            v-model="form.description"
+            rows="3"
+            placeholder="Optional notes for the event card"
+          ></textarea>
+        </label>
+        <p v-if="submitMessage" :class="submitMessageClass">{{ submitMessage }}</p>
+        <div class="add-show-panel__actions">
+          <button type="button" class="button-secondary" @click="toggleAddForm">Cancel</button>
+          <button type="submit" class="button-primary" :disabled="isSubmitDisabled">
+            {{ isSubmitting ? 'Saving…' : 'Save show' }}
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <EventFiltersBar
+      :search-text="searchText"
+      :date-range="dateRange"
+      :sort="sort"
+      @update:search-text="searchText = $event"
+      @update:date-range="dateRange = $event"
+      @update:sort="sort = $event"
+    />
+
+    <section class="events-page__results">
+      <div>
+        <p class="events-page__results-label">{{ filteredEvents.length }} shows</p>
+        <p class="events-page__results-subtitle">{{ sortSummary }}</p>
+      </div>
+      <button class="button-secondary" type="button" @click="clearFilters">Reset filters</button>
+    </section>
+
+    <section v-if="filteredEvents.length" class="events-page__list">
+      <EventCard v-for="event in filteredEvents" :key="event.id" :event="event" />
+    </section>
+
+    <section v-else class="events-page__empty">
+      <h2>No shows match those filters.</h2>
+      <p>Try a different city, band, venue, or date range.</p>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import EventCard from '../components/events/EventCard.vue';
+import EventFiltersBar from '../components/events/EventFiltersBar.vue';
+import { useEventFilters } from '../composables/useEventFilters';
+import { sampleEvents } from '../data/sampleEvents';
+import { createConcert } from '../composables/useApi';
+import { useAuth } from '../composables/useAuth';
+import { mapConcertToEventListItem, type EventListItem } from '../types/events';
+
+const { user } = useAuth();
+
+const createdEvents = ref<EventListItem[]>([]);
+const demoEvents = computed(() => [...createdEvents.value, ...sampleEvents]);
+const { searchText, dateRange, sort, filteredEvents, clearFilters } = useEventFilters(demoEvents);
+
+const showAddForm = ref(false);
+const isSubmitting = ref(false);
+const submitMessage = ref('');
+const submitMessageType = ref<'success' | 'error'>('success');
+const pageMessage = ref('');
+const pageMessageType = ref<'success' | 'error'>('success');
+
+const form = reactive({
+  title: '',
+  genre: '',
+  artistName: '',
+  venueName: '',
+  city: '',
+  state: 'NC',
+  date: '',
+  time: '19:00',
+  posterUrl: '',
+  description: '',
+});
+
+const sortSummary = computed(() =>
+  sort.value === 'soonest' ? 'Sorted by earliest upcoming start time.' : 'Sorted by featured demo priority.'
+);
+
+const isSubmitDisabled = computed(
+  () =>
+    isSubmitting.value ||
+    !form.title.trim() ||
+    !form.genre.trim() ||
+    !form.artistName.trim() ||
+    !form.venueName.trim() ||
+    !form.date ||
+    !form.time
+);
+
+const submitMessageClass = computed(() =>
+  submitMessageType.value === 'success'
+    ? 'add-show-panel__message add-show-panel__message--success'
+    : 'add-show-panel__message add-show-panel__message--error'
+);
+
+const pageMessageClass = computed(() =>
+  pageMessageType.value === 'success'
+    ? 'events-page__message events-page__message--success'
+    : 'events-page__message events-page__message--error'
+);
+
+const toggleAddForm = () => {
+  showAddForm.value = !showAddForm.value;
+  submitMessage.value = '';
+};
+
+const resetForm = () => {
+  form.title = '';
+  form.genre = '';
+  form.artistName = '';
+  form.venueName = '';
+  form.city = '';
+  form.state = 'NC';
+  form.date = '';
+  form.time = '19:00';
+  form.posterUrl = '';
+  form.description = '';
+};
+
+const buildStartsAt = () => {
+  const localDate = new Date(`${form.date}T${form.time}`);
+  return localDate.toISOString();
+};
+
+const handleSubmit = async () => {
+  if (!user.value || isSubmitDisabled.value) {
+    return;
+  }
+
+  isSubmitting.value = true;
+  submitMessage.value = '';
+  pageMessage.value = '';
+
+  try {
+    const token = await user.value.getIdToken();
+    const concert = await createConcert(token, {
+      title: form.title.trim(),
+      genre: form.genre.trim(),
+      startsAt: buildStartsAt(),
+      venues: [
+        {
+          name: form.venueName.trim(),
+          city: form.city.trim() || undefined,
+          state: form.state || undefined,
+        },
+      ],
+      artists: [
+        {
+          name: form.artistName.trim(),
+          role: 'headliner',
+          genre: form.genre.trim(),
+        },
+      ],
+      description: form.description.trim() || undefined,
+    });
+
+    createdEvents.value = [
+      mapConcertToEventListItem(concert, {
+        posterUrl:
+          form.posterUrl.trim() ||
+          'https://placehold.co/720x900/e6ece4/31453a?text=New+Show',
+        sourceLabel: 'Your submission',
+        displayTags: [form.genre.trim(), 'new', 'my concert'],
+        demoRank: 100,
+      }),
+      ...createdEvents.value,
+    ];
+
+    submitMessageType.value = 'success';
+    submitMessage.value = 'Show saved. It should also appear on your My Concerts home feed.';
+    pageMessageType.value = 'success';
+    pageMessage.value = 'New show saved and added to the demo feed.';
+    window.dispatchEvent(new CustomEvent('concerts:changed'));
+    resetForm();
+    showAddForm.value = false;
+  } catch {
+    submitMessageType.value = 'error';
+    submitMessage.value = 'Unable to save the show right now.';
+    pageMessageType.value = 'error';
+    pageMessage.value = 'Unable to save the show right now.';
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.events-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.events-page__hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.75rem;
+  border-radius: 1.2rem;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.74)),
+    linear-gradient(135deg, rgba(229, 231, 235, 0.75), rgba(244, 246, 244, 0.95));
+  border: 1px solid var(--border);
+}
+
+.events-page__hero-copy p,
+.events-page__results p,
+.events-page__empty h2,
+.events-page__empty p,
+.add-show-panel__header h2,
+.add-show-panel__header p {
+  margin: 0;
+}
+
+.events-page__eyebrow {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-light);
+  margin-bottom: 0.45rem;
+}
+
+.events-page__intro {
+  max-width: 52rem;
+  color: var(--text-light);
+  margin-top: 0.8rem;
+}
+
+.events-page__toggle,
+.button-primary,
+.button-secondary {
+  border-radius: 999px;
+  padding: 0.75rem 1.1rem;
+  font-weight: 600;
+}
+
+.events-page__toggle,
+.button-primary {
+  border: 1px solid var(--primary);
+  background: var(--primary);
+  color: white;
+}
+
+.button-secondary {
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--text-dark);
+}
+
+.add-show-panel {
+  padding: 1.4rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.add-show-panel__header {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.add-show-panel__header p {
+  color: var(--text-light);
+}
+
+.add-show-panel__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.add-show-panel__form label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.add-show-panel__form span {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.add-show-panel__form input,
+.add-show-panel__form select,
+.add-show-panel__form textarea {
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: white;
+  font: inherit;
+  color: var(--text-dark);
+  box-sizing: border-box;
+}
+
+.add-show-panel__message {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.add-show-panel__message--success {
+  color: #285d33;
+}
+
+.add-show-panel__message--error {
+  color: #b42318;
+}
+
+.add-show-panel__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.events-page__results {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.events-page__results-label {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.events-page__message {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid var(--border);
+}
+
+.events-page__message--success {
+  background: rgba(40, 93, 51, 0.08);
+  color: #285d33;
+}
+
+.events-page__message--error {
+  background: rgba(180, 35, 24, 0.08);
+  color: #b42318;
+}
+
+.events-page__results-subtitle {
+  color: var(--text-light);
+}
+
+.events-page__list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.events-page__empty {
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  border: 1px dashed var(--border);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.events-page__empty p {
+  margin-top: 0.45rem;
+  color: var(--text-light);
+}
+
+@media (min-width: 760px) {
+  .events-page__hero {
+    grid-template-columns: 1fr auto;
+    align-items: end;
+  }
+
+  .add-show-panel__form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .add-show-panel__full,
+  .add-show-panel__actions {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 759px) {
+  .events-page__results {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .add-show-panel__actions {
+    flex-direction: column;
+  }
+}
+</style>

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -1,6 +1,8 @@
 // src/router.ts
 import { createRouter, createWebHistory } from 'vue-router';
 import { getAuth } from 'firebase/auth';
+import EventsPage from './pages/EventsPage.vue';
+import { routeLoading } from './stores/routeLoading';
 import HomePage from './views/HomePage.vue';
 import LoginPage from './views/LoginPage.vue';
 import ProfilePage from './views/ProfilePage.vue';
@@ -22,6 +24,12 @@ const routes = [
     component: ProfilePage,
     meta: { requiresAuth: true },
   },
+  {
+    path: '/events',
+    name: 'Events',
+    component: EventsPage,
+    meta: { requiresAuth: true },
+  },
 ];
 
 const router = createRouter({
@@ -30,6 +38,7 @@ const router = createRouter({
 });
 
 router.beforeEach((to, _from, next) => {
+  routeLoading.value = true;
   const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
   const isAuthenticated = getAuth().currentUser;
 
@@ -43,6 +52,14 @@ router.beforeEach((to, _from, next) => {
   } else {
     next();
   }
+});
+
+router.afterEach(() => {
+  routeLoading.value = false;
+});
+
+router.onError(() => {
+  routeLoading.value = false;
 });
 
 export default router;

--- a/client/src/stores/routeLoading.ts
+++ b/client/src/stores/routeLoading.ts
@@ -1,0 +1,3 @@
+import { ref } from 'vue';
+
+export const routeLoading = ref(false);

--- a/client/src/types/events.ts
+++ b/client/src/types/events.ts
@@ -1,0 +1,50 @@
+export interface EventVenue {
+  name: string;
+  city?: string;
+  state?: string;
+  country?: string;
+}
+
+export interface EventArtist {
+  name: string;
+  role?: string;
+  genre?: string;
+}
+
+export interface ConcertApiItem {
+  id: string;
+  title: string;
+  genre: string;
+  startsAt: string;
+  endsAt?: string | null;
+  venues: EventVenue[];
+  artists: EventArtist[];
+  description?: string | null;
+}
+
+export interface ConcertApiResponse {
+  data: ConcertApiItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface EventListItem extends ConcertApiItem {
+  posterUrl: string;
+  sourceLabel: string;
+  displayTags: string[];
+  demoRank: number;
+}
+
+export function mapConcertToEventListItem(
+  concert: ConcertApiItem,
+  overrides?: Partial<Pick<EventListItem, 'posterUrl' | 'sourceLabel' | 'displayTags' | 'demoRank'>>
+): EventListItem {
+  return {
+    ...concert,
+    posterUrl: overrides?.posterUrl ?? 'https://placehold.co/720x900?text=Live+Music',
+    sourceLabel: overrides?.sourceLabel ?? 'EZ Vibes Demo',
+    displayTags: overrides?.displayTags ?? [concert.genre],
+    demoRank: overrides?.demoRank ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary
- add an authenticated /events route as a parallel concert calendar surface
- add reusable event cards, filters, and a mobile-first events feed UI
- wire the Add Show flow to POST /concerts and refresh My Concerts after creates

## Notes
- preserves the current main auth flow and / landing behavior
- keeps Concert Calendar separate from My Concerts for now
- /events still includes seeded demo data alongside newly created concerts on this branch

## Validation
- npm run build --prefix client