### PR TITLE
feat: add async OCR worker for ingestion jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ GCP_CLIENT_EMAIL=
 # Use a single-line key with \n for line breaks
 GCP_PRIVATE_KEY=
 GCS_INGESTION_BUCKET=
+
+# OCR worker runtime
+INGESTION_WORKER_POLL_INTERVAL_MS=5000
+INGESTION_WORKER_ONCE=false

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ $ npm run start:dev
 
 The API will be running at `http://localhost:3001`.
 
+### 1b. Start the OCR worker
+
+The ingestion worker runs as a separate process from the NestJS API. It polls for queued ingestion jobs, reads the uploaded image from Cloud Storage, runs Google Vision OCR, and persists job state back to Postgres.
+
+```bash
+# in another terminal
+$ npm run start:worker:dev
+```
+
+For a one-shot local run (useful in tests or when debugging one job):
+
+```bash
+$ npm run start:worker:once
+```
+
 ### 2. Start the Frontend Client
 
 In a separate terminal, set up and run the Vue.js client.
@@ -70,6 +85,27 @@ The frontend will be available at `http://localhost:5173`.
 ### CORS
 
 The backend is configured to accept cross-origin requests only from the frontend client. This is defined in `src/main.ts`. Any changes to the client's address (`http://localhost:5173`) must be reflected there.
+
+### Ingestion / OCR worker
+
+The ingestion flow now works in two phases:
+
+1. `POST /ingestion/uploads` stores the flyer image in GCS and creates a queued ingestion job.
+2. `POST /ingestion/jobs` can queue another OCR job for an existing uploaded asset owned by the current user.
+3. The worker process claims queued jobs, runs Google Vision OCR, and transitions jobs through `queued -> processing -> parsed` or `failed`.
+
+Relevant env vars:
+
+```bash
+GCS_INGESTION_BUCKET=
+GCP_PROJECT_ID=
+GCP_CLIENT_EMAIL=
+GCP_PRIVATE_KEY=
+INGESTION_WORKER_POLL_INTERVAL_MS=5000
+INGESTION_WORKER_ONCE=false
+```
+
+Production note: keep credentials in Secret Manager or runtime env injection rather than committed files.
 
 ## User Signup Flow
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^7.19.0",
+        "@google-cloud/vision": "^5.3.4",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -1648,6 +1649,206 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@google-cloud/vision": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vision/-/vision-5.3.5.tgz",
+      "integrity": "sha512-SfLE3o+K/4KtZUU2m6XJuSHIKPwrlbVpHLeO5qsF5f0qPyM61357A38jvyOONBtQW0plriH3+rzGB0chPI5DYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/promisify": "^5.0.0",
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/@google-cloud/promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+      "integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/google-gax": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.1.0",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.3",
+        "retry-request": "^8.0.0",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/vision/node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -2796,7 +2997,6 @@
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -5736,6 +5936,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -6747,6 +6956,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7009,6 +7241,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -9990,6 +10234,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -10280,7 +10544,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11301,6 +11564,88 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/router": {
@@ -13383,6 +13728,15 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "start:worker": "node dist/worker",
+    "start:worker:dev": "ts-node -r tsconfig-paths/register src/worker.ts",
+    "start:worker:once": "INGESTION_WORKER_ONCE=true ts-node -r tsconfig-paths/register src/worker.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -23,6 +26,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.19.0",
+    "@google-cloud/vision": "^5.3.4",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/src/ingestion/dto/create-ingestion-job.dto.ts
+++ b/src/ingestion/dto/create-ingestion-job.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class CreateIngestionJobDto {
+  @IsUUID()
+  sourceAssetId: string;
+}

--- a/src/ingestion/entities/ingestion-job.entity.ts
+++ b/src/ingestion/entities/ingestion-job.entity.ts
@@ -35,6 +35,21 @@ export class IngestionJob {
   @Column({ nullable: true, type: 'text' })
   ocrText?: string;
 
+  @Column({ nullable: true })
+  ocrProvider?: string;
+
+  @Column({ nullable: true, type: 'float' })
+  ocrConfidence?: number;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  processingStartedAt?: Date;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  completedAt?: Date;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  failedAt?: Date;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/ingestion/ingestion.controller.spec.ts
+++ b/src/ingestion/ingestion.controller.spec.ts
@@ -3,6 +3,7 @@ import { IngestionController } from './ingestion.controller';
 describe('IngestionController', () => {
   const ingestionService = {
     uploadImage: jest.fn(),
+    createJob: jest.fn(),
     getJob: jest.fn(),
   };
 
@@ -31,6 +32,20 @@ describe('IngestionController', () => {
   });
 
   it('should request a job for the current user', async () => {
+    ingestionService.createJob.mockResolvedValue({ id: 'job-1' });
+
+    await controller.createJob(
+      { sourceAssetId: 'asset-1' },
+      { uid: 'uid-1' } as any,
+    );
+
+    expect(ingestionService.createJob).toHaveBeenCalledWith(
+      { sourceAssetId: 'asset-1' },
+      'uid-1',
+    );
+  });
+
+  it('should request a job lookup for the current user', async () => {
     ingestionService.getJob.mockResolvedValue({ id: 'job-1' });
 
     await controller.getJob('job-1', { uid: 'uid-1' } as any);

--- a/src/ingestion/ingestion.controller.ts
+++ b/src/ingestion/ingestion.controller.ts
@@ -13,6 +13,7 @@ import type { DecodedIdToken } from 'firebase-admin/auth';
 import { memoryStorage } from 'multer';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { FirebaseAuthGuard } from '../auth/firebase-auth/firebase-auth.guard';
+import { CreateIngestionJobDto } from './dto/create-ingestion-job.dto';
 import { CreateIngestionUploadDto } from './dto/create-ingestion-upload.dto';
 import { IngestionService } from './ingestion.service';
 
@@ -36,6 +37,15 @@ export class IngestionController {
     @CurrentUser() user: DecodedIdToken,
   ) {
     return this.ingestionService.uploadImage(file, body, user.uid);
+  }
+
+  @Post('jobs')
+  @UseGuards(FirebaseAuthGuard)
+  async createJob(
+    @Body() body: CreateIngestionJobDto,
+    @CurrentUser() user: DecodedIdToken,
+  ) {
+    return this.ingestionService.createJob(body, user.uid);
   }
 
   @Get('jobs/:id')

--- a/src/ingestion/ingestion.module.ts
+++ b/src/ingestion/ingestion.module.ts
@@ -6,6 +6,10 @@ import { IngestionJob } from './entities/ingestion-job.entity';
 import { SourceAsset } from './entities/source-asset.entity';
 import { IngestionController } from './ingestion.controller';
 import { IngestionService } from './ingestion.service';
+import { VisionOcrService } from './ocr/vision-ocr.service';
+import { IngestionStorageService } from './storage/ingestion-storage.service';
+import { IngestionWorkerRunner } from './worker/ingestion-worker.runner';
+import { IngestionWorkerService } from './worker/ingestion-worker.service';
 
 @Module({
   imports: [
@@ -14,7 +18,13 @@ import { IngestionService } from './ingestion.service';
     TypeOrmModule.forFeature([SourceAsset, IngestionJob]),
   ],
   controllers: [IngestionController],
-  providers: [IngestionService],
-  exports: [IngestionService],
+  providers: [
+    IngestionService,
+    IngestionStorageService,
+    VisionOcrService,
+    IngestionWorkerService,
+    IngestionWorkerRunner,
+  ],
+  exports: [IngestionService, IngestionWorkerService, IngestionWorkerRunner],
 })
 export class IngestionModule {}

--- a/src/ingestion/ingestion.service.spec.ts
+++ b/src/ingestion/ingestion.service.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
 import { IngestionService } from './ingestion.service';
 import { SourceAsset } from './entities/source-asset.entity';
 import { IngestionJob } from './entities/ingestion-job.entity';
+import { IngestionStorageService } from './storage/ingestion-storage.service';
 
 describe('IngestionService', () => {
   let service: IngestionService;
@@ -11,6 +13,7 @@ describe('IngestionService', () => {
   const sourceAssetRepository = {
     create: jest.fn(),
     save: jest.fn(),
+    findOne: jest.fn(),
   };
 
   const ingestionJobRepository = {
@@ -21,6 +24,11 @@ describe('IngestionService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+
+    const storageService = {
+      getConfiguredBucketName: jest.fn().mockReturnValue('test-bucket'),
+      uploadObject: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -33,6 +41,10 @@ describe('IngestionService', () => {
               return undefined;
             }),
           },
+        },
+        {
+          provide: IngestionStorageService,
+          useValue: storageService,
         },
         {
           provide: getRepositoryToken(SourceAsset),
@@ -69,16 +81,6 @@ describe('IngestionService', () => {
       stage: 'uploaded',
     });
 
-    const bucketMock = {
-      file: jest.fn().mockReturnValue({
-        save: jest.fn().mockResolvedValue(undefined),
-      }),
-    };
-
-    Object.defineProperty(service as object, 'storage', {
-      value: { bucket: jest.fn().mockReturnValue(bucketMock) },
-    });
-
     const result = await service.uploadImage(
       file,
       { city: 'wilmington', source: 'flyer_upload' },
@@ -96,5 +98,52 @@ describe('IngestionService', () => {
     expect(result.ingestionJobId).toBe('job-1');
     expect(result.city).toBe('wilmington');
     expect(result.source).toBe('flyer_upload');
+  });
+
+  it('should create a queued OCR job for an owned source asset', async () => {
+    sourceAssetRepository.findOne.mockResolvedValue({
+      id: 'asset-1',
+      uploadedByUid: 'uid-1',
+    });
+    ingestionJobRepository.create.mockImplementation((value) => value);
+    ingestionJobRepository.save.mockResolvedValue({
+      id: 'job-2',
+      sourceAssetId: 'asset-1',
+      status: 'queued',
+      stage: 'queued',
+      sourceAsset: {
+        id: 'asset-1',
+        storageUri: 'gs://bucket/path.jpg',
+        objectName: 'path.jpg',
+        bucket: 'bucket',
+        mimeType: 'image/jpeg',
+        originalFilename: 'poster.jpg',
+        source: 'flyer_upload',
+        size: 123,
+        uploadedByUid: 'uid-1',
+        createdAt: new Date(),
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.createJob({ sourceAssetId: 'asset-1' }, 'uid-1');
+
+    expect(ingestionJobRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceAssetId: 'asset-1',
+        status: 'queued',
+        stage: 'queued',
+      }),
+    );
+    expect(result.id).toBe('job-2');
+  });
+
+  it('should reject job creation for an asset the user does not own', async () => {
+    sourceAssetRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.createJob({ sourceAssetId: 'missing-asset' }, 'uid-1'),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/src/ingestion/ingestion.service.ts
+++ b/src/ingestion/ingestion.service.ts
@@ -1,70 +1,41 @@
 import {
   BadRequestException,
   Injectable,
-  InternalServerErrorException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Storage } from '@google-cloud/storage';
 import { randomUUID } from 'crypto';
 import { extname } from 'path';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CreateIngestionJobDto } from './dto/create-ingestion-job.dto';
 import { CreateIngestionUploadDto } from './dto/create-ingestion-upload.dto';
 import { IngestionJob } from './entities/ingestion-job.entity';
 import { SourceAsset } from './entities/source-asset.entity';
 import { IngestionJobResponse } from './interfaces/ingestion-job-response.interface';
 import { IngestionUploadResult } from './interfaces/ingestion-upload-result.interface';
+import { IngestionStorageService } from './storage/ingestion-storage.service';
 
 type UploadableFile = Express.Multer.File;
 
 @Injectable()
 export class IngestionService {
-  private readonly bucketName?: string;
-  private readonly storage: Storage;
+  private readonly logger = new Logger(IngestionService.name);
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly storageService: IngestionStorageService,
     @InjectRepository(SourceAsset)
     private readonly sourceAssetRepository: Repository<SourceAsset>,
     @InjectRepository(IngestionJob)
     private readonly ingestionJobRepository: Repository<IngestionJob>,
-  ) {
-    this.bucketName = this.configService.get<string>('GCS_INGESTION_BUCKET');
-
-    const projectId =
-      this.configService.get<string>('GCP_PROJECT_ID') ??
-      this.configService.get<string>('FIREBASE_PROJECT_ID');
-    const clientEmail =
-      this.configService.get<string>('GCP_CLIENT_EMAIL') ??
-      this.configService.get<string>('FIREBASE_CLIENT_EMAIL');
-    const privateKey = (
-      this.configService.get<string>('GCP_PRIVATE_KEY') ??
-      this.configService.get<string>('FIREBASE_PRIVATE_KEY')
-    )?.replace(/\\n/g, '\n');
-
-    this.storage =
-      projectId && clientEmail && privateKey
-        ? new Storage({
-            projectId,
-            credentials: {
-              client_email: clientEmail,
-              private_key: privateKey,
-            },
-          })
-        : new Storage();
-  }
+  ) {}
 
   async uploadImage(
     file: UploadableFile,
     dto: CreateIngestionUploadDto,
     uid: string,
   ): Promise<IngestionUploadResult> {
-    if (!this.bucketName) {
-      throw new InternalServerErrorException(
-        'GCS_INGESTION_BUCKET is not configured.',
-      );
-    }
+    const bucketName = this.storageService.getConfiguredBucketName();
 
     if (!file) {
       throw new BadRequestException('An image file is required.');
@@ -80,27 +51,25 @@ export class IngestionService {
 
     const uploadedAt = new Date().toISOString();
     const objectName = this.buildObjectName(file.originalname, uid, uploadedAt);
-    const bucket = this.storage.bucket(this.bucketName);
-    const object = bucket.file(objectName);
 
-    await object.save(file.buffer, {
-      resumable: false,
-      contentType: file.mimetype,
-      metadata: {
-        metadata: {
-          uploadedByUid: uid,
-          city: dto.city ?? '',
-          source: dto.source ?? 'flyer_upload',
-          originalFilename: file.originalname,
-        },
+    await this.storageService.uploadObject(
+      bucketName,
+      objectName,
+      file.buffer,
+      {
+        uploadedByUid: uid,
+        city: dto.city ?? '',
+        source: dto.source ?? 'flyer_upload',
+        originalFilename: file.originalname,
       },
-    });
+      file.mimetype,
+    );
 
     const sourceAsset = await this.sourceAssetRepository.save(
       this.sourceAssetRepository.create({
-        storageUri: `gs://${this.bucketName}/${objectName}`,
+        storageUri: `gs://${bucketName}/${objectName}`,
         objectName,
-        bucket: this.bucketName,
+        bucket: bucketName,
         mimeType: file.mimetype,
         originalFilename: file.originalname,
         city: dto.city,
@@ -114,7 +83,7 @@ export class IngestionService {
       this.ingestionJobRepository.create({
         sourceAssetId: sourceAsset.id,
         status: 'queued',
-        stage: 'uploaded',
+        stage: 'queued',
       }),
     );
 
@@ -122,9 +91,9 @@ export class IngestionService {
       sourceAssetId: sourceAsset.id,
       ingestionJobId: ingestionJob.id,
       status: ingestionJob.status,
-      bucket: this.bucketName,
+      bucket: bucketName,
       objectName,
-      storageUri: `gs://${this.bucketName}/${objectName}`,
+      storageUri: `gs://${bucketName}/${objectName}`,
       contentType: file.mimetype,
       size: file.size,
       originalFilename: file.originalname,
@@ -132,6 +101,38 @@ export class IngestionService {
       source: dto.source ?? 'flyer_upload',
       uploadedAt,
     };
+  }
+
+  async createJob(
+    dto: CreateIngestionJobDto,
+    uid: string,
+  ): Promise<IngestionJobResponse> {
+    const sourceAsset = await this.sourceAssetRepository.findOne({
+      where: {
+        id: dto.sourceAssetId,
+        uploadedByUid: uid,
+      },
+    });
+
+    if (!sourceAsset) {
+      throw new NotFoundException(
+        `Source asset ${dto.sourceAssetId} not found`,
+      );
+    }
+
+    const ingestionJob = await this.ingestionJobRepository.save(
+      this.ingestionJobRepository.create({
+        sourceAssetId: sourceAsset.id,
+        sourceAsset,
+        status: 'queued',
+        stage: 'queued',
+      }),
+    );
+
+    return this.toJobResponse({
+      ...ingestionJob,
+      sourceAsset,
+    } as IngestionJob);
   }
 
   async getJob(id: string, uid: string): Promise<IngestionJobResponse> {
@@ -144,11 +145,25 @@ export class IngestionService {
       throw new NotFoundException(`Ingestion job ${id} not found`);
     }
 
+    return this.toJobResponse(job);
+  }
+
+  private toJobResponse(job: IngestionJob): IngestionJobResponse {
+    if (!job.sourceAsset) {
+      this.logger.warn(`Ingestion job ${job.id} was loaded without sourceAsset`);
+    }
+
     return {
       id: job.id,
       status: job.status,
       stage: job.stage,
       errorMessage: job.errorMessage,
+      ocrText: job.ocrText,
+      ocrProvider: job.ocrProvider,
+      ocrConfidence: job.ocrConfidence,
+      processingStartedAt: job.processingStartedAt,
+      completedAt: job.completedAt,
+      failedAt: job.failedAt,
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
       sourceAsset: {

--- a/src/ingestion/interfaces/ingestion-job-response.interface.ts
+++ b/src/ingestion/interfaces/ingestion-job-response.interface.ts
@@ -3,6 +3,12 @@ export interface IngestionJobResponse {
   status: string;
   stage?: string;
   errorMessage?: string;
+  ocrText?: string;
+  ocrProvider?: string;
+  ocrConfidence?: number;
+  processingStartedAt?: Date;
+  completedAt?: Date;
+  failedAt?: Date;
   createdAt: Date;
   updatedAt: Date;
   sourceAsset: {

--- a/src/ingestion/ocr/vision-ocr.service.ts
+++ b/src/ingestion/ocr/vision-ocr.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ImageAnnotatorClient, protos } from '@google-cloud/vision';
+
+export interface OcrResult {
+  provider: string;
+  text: string;
+  confidence?: number;
+}
+
+@Injectable()
+export class VisionOcrService {
+  private readonly client: ImageAnnotatorClient;
+
+  constructor(private readonly configService: ConfigService) {
+    const projectId =
+      this.configService.get<string>('GCP_PROJECT_ID') ??
+      this.configService.get<string>('FIREBASE_PROJECT_ID');
+    const clientEmail =
+      this.configService.get<string>('GCP_CLIENT_EMAIL') ??
+      this.configService.get<string>('FIREBASE_CLIENT_EMAIL');
+    const privateKey = (
+      this.configService.get<string>('GCP_PRIVATE_KEY') ??
+      this.configService.get<string>('FIREBASE_PRIVATE_KEY')
+    )?.replace(/\\n/g, '\n');
+
+    this.client =
+      projectId && clientEmail && privateKey
+        ? new ImageAnnotatorClient({
+            projectId,
+            credentials: {
+              client_email: clientEmail,
+              private_key: privateKey,
+            },
+          })
+        : new ImageAnnotatorClient();
+  }
+
+  async extractText(bucket: string, objectName: string): Promise<OcrResult> {
+    const [response] = await this.client.documentTextDetection({
+      image: {
+        source: {
+          imageUri: `gs://${bucket}/${objectName}`,
+        },
+      },
+    });
+
+    const text =
+      response.fullTextAnnotation?.text?.trim() ||
+      response.textAnnotations?.[0]?.description?.trim() ||
+      '';
+
+    if (!text) {
+      throw new Error('Vision OCR returned no text.');
+    }
+
+    return {
+      provider: 'google-vision',
+      text,
+      confidence: this.calculateConfidence(response.fullTextAnnotation),
+    };
+  }
+
+  private calculateConfidence(
+    annotation?: protos.google.cloud.vision.v1.ITextAnnotation | null,
+  ): number | undefined {
+    const pageConfidences = annotation?.pages
+      ?.map((page) => page.confidence)
+      .filter((value): value is number => typeof value === 'number');
+
+    if (!pageConfidences?.length) {
+      return undefined;
+    }
+
+    const average =
+      pageConfidences.reduce((sum, value) => sum + value, 0) /
+      pageConfidences.length;
+
+    return Number(average.toFixed(4));
+  }
+}

--- a/src/ingestion/storage/ingestion-storage.service.ts
+++ b/src/ingestion/storage/ingestion-storage.service.ts
@@ -1,0 +1,72 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Storage } from '@google-cloud/storage';
+
+@Injectable()
+export class IngestionStorageService {
+  private readonly storage: Storage;
+
+  constructor(private readonly configService: ConfigService) {
+    const projectId =
+      this.configService.get<string>('GCP_PROJECT_ID') ??
+      this.configService.get<string>('FIREBASE_PROJECT_ID');
+    const clientEmail =
+      this.configService.get<string>('GCP_CLIENT_EMAIL') ??
+      this.configService.get<string>('FIREBASE_CLIENT_EMAIL');
+    const privateKey = (
+      this.configService.get<string>('GCP_PRIVATE_KEY') ??
+      this.configService.get<string>('FIREBASE_PRIVATE_KEY')
+    )?.replace(/\\n/g, '\n');
+
+    this.storage =
+      projectId && clientEmail && privateKey
+        ? new Storage({
+            projectId,
+            credentials: {
+              client_email: clientEmail,
+              private_key: privateKey,
+            },
+          })
+        : new Storage();
+  }
+
+  getConfiguredBucketName(): string {
+    const bucketName = this.configService.get<string>('GCS_INGESTION_BUCKET');
+
+    if (!bucketName) {
+      throw new InternalServerErrorException(
+        'GCS_INGESTION_BUCKET is not configured.',
+      );
+    }
+
+    return bucketName;
+  }
+
+  async uploadObject(
+    bucketName: string,
+    objectName: string,
+    buffer: Buffer,
+    metadata: Record<string, string>,
+    contentType: string,
+  ): Promise<void> {
+    await this.storage.bucket(bucketName).file(objectName).save(buffer, {
+      resumable: false,
+      contentType,
+      metadata: {
+        metadata,
+      },
+    });
+  }
+
+  async objectExists(bucketName: string, objectName: string): Promise<boolean> {
+    const [exists] = await this.storage
+      .bucket(bucketName)
+      .file(objectName)
+      .exists();
+
+    return exists;
+  }
+}

--- a/src/ingestion/worker/ingestion-worker.runner.ts
+++ b/src/ingestion/worker/ingestion-worker.runner.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IngestionWorkerService } from './ingestion-worker.service';
+
+@Injectable()
+export class IngestionWorkerRunner {
+  private readonly logger = new Logger(IngestionWorkerRunner.name);
+
+  constructor(private readonly ingestionWorkerService: IngestionWorkerService) {}
+
+  async run(): Promise<void> {
+    const pollIntervalMs = Number(
+      process.env.INGESTION_WORKER_POLL_INTERVAL_MS ?? '5000',
+    );
+    const runOnce = ['1', 'true', 'yes'].includes(
+      String(process.env.INGESTION_WORKER_ONCE ?? '').toLowerCase(),
+    );
+
+    this.logger.log(
+      runOnce
+        ? 'Starting ingestion worker in one-shot mode'
+        : `Starting ingestion worker loop (poll every ${pollIntervalMs}ms)`,
+    );
+
+    do {
+      const result = await this.ingestionWorkerService.processNextQueuedJob();
+
+      if (!result && runOnce) {
+        this.logger.log('No queued ingestion jobs found.');
+        return;
+      }
+
+      if (runOnce) {
+        this.logger.log(
+          result
+            ? `Processed ingestion job ${result.jobId} with status ${result.status}`
+            : 'No queued ingestion jobs found.',
+        );
+        return;
+      }
+
+      if (!result) {
+        await this.sleep(pollIntervalMs);
+      }
+    } while (true);
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/ingestion/worker/ingestion-worker.service.spec.ts
+++ b/src/ingestion/worker/ingestion-worker.service.spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { IngestionJob } from '../entities/ingestion-job.entity';
+import { SourceAsset } from '../entities/source-asset.entity';
+import { VisionOcrService } from '../ocr/vision-ocr.service';
+import { IngestionStorageService } from '../storage/ingestion-storage.service';
+import { IngestionWorkerService } from './ingestion-worker.service';
+
+describe('IngestionWorkerService', () => {
+  let service: IngestionWorkerService;
+
+  const sourceAsset: SourceAsset = {
+    id: 'asset-1',
+    storageUri: 'gs://test-bucket/ingestion/uploads/flyer.jpg',
+    objectName: 'ingestion/uploads/flyer.jpg',
+    bucket: 'test-bucket',
+    mimeType: 'image/jpeg',
+    originalFilename: 'flyer.jpg',
+    source: 'flyer_upload',
+    uploadedByUid: 'uid-1',
+    size: 42,
+    createdAt: new Date(),
+    ingestionJobs: [],
+  };
+
+  const jobs = new Map<string, IngestionJob>();
+
+  const ingestionJobRepository = {
+    findOne: jest.fn(async (options: any) => {
+      if (options?.where?.id) {
+        return jobs.get(options.where.id) ?? null;
+      }
+
+      if (options?.where?.status === 'queued') {
+        return (
+          [...jobs.values()]
+            .filter((job) => job.status === 'queued')
+            .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[0] ??
+          null
+        );
+      }
+
+      return null;
+    }),
+    update: jest.fn(async (criteria: any, patch: Partial<IngestionJob>) => {
+      const id = typeof criteria === 'string' ? criteria : criteria.id;
+      const expectedStatus = typeof criteria === 'string' ? undefined : criteria.status;
+      const job = jobs.get(id);
+
+      if (!job) {
+        return { affected: 0 };
+      }
+
+      if (expectedStatus && job.status !== expectedStatus) {
+        return { affected: 0 };
+      }
+
+      Object.assign(job, patch, { updatedAt: new Date() });
+      jobs.set(id, job);
+
+      return { affected: 1 };
+    }),
+  };
+
+  const ingestionStorageService = {
+    objectExists: jest.fn(),
+  };
+
+  const visionOcrService = {
+    extractText: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jobs.clear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IngestionWorkerService,
+        {
+          provide: getRepositoryToken(IngestionJob),
+          useValue: ingestionJobRepository,
+        },
+        {
+          provide: IngestionStorageService,
+          useValue: ingestionStorageService,
+        },
+        {
+          provide: VisionOcrService,
+          useValue: visionOcrService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<IngestionWorkerService>(IngestionWorkerService);
+  });
+
+  it('should claim a queued job and transition it to parsed after OCR succeeds', async () => {
+    jobs.set('job-1', {
+      id: 'job-1',
+      sourceAssetId: sourceAsset.id,
+      sourceAsset,
+      status: 'queued',
+      stage: 'queued',
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date('2026-04-01T00:00:00Z'),
+    } as IngestionJob);
+
+    ingestionStorageService.objectExists.mockResolvedValue(true);
+    visionOcrService.extractText.mockResolvedValue({
+      provider: 'google-vision',
+      text: 'Local band at Cat\'s Cradle',
+      confidence: 0.91,
+    });
+
+    const result = await service.processNextQueuedJob();
+
+    expect(result).toEqual({
+      jobId: 'job-1',
+      status: 'parsed',
+      stage: 'parsed',
+    });
+    expect(jobs.get('job-1')).toEqual(
+      expect.objectContaining({
+        status: 'parsed',
+        stage: 'parsed',
+        ocrProvider: 'google-vision',
+        ocrText: 'Local band at Cat\'s Cradle',
+        ocrConfidence: 0.91,
+      }),
+    );
+  });
+
+  it('should mark a job failed when the source object is missing from GCS', async () => {
+    jobs.set('job-2', {
+      id: 'job-2',
+      sourceAssetId: sourceAsset.id,
+      sourceAsset,
+      status: 'queued',
+      stage: 'queued',
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date('2026-04-01T00:00:00Z'),
+    } as IngestionJob);
+
+    ingestionStorageService.objectExists.mockResolvedValue(false);
+
+    const result = await service.processNextQueuedJob();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        jobId: 'job-2',
+        status: 'failed',
+      }),
+    );
+    expect(jobs.get('job-2')).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        stage: 'failed',
+        errorMessage: expect.stringContaining('was not found'),
+      }),
+    );
+  });
+
+  it('should mark a job failed when Vision OCR throws', async () => {
+    jobs.set('job-3', {
+      id: 'job-3',
+      sourceAssetId: sourceAsset.id,
+      sourceAsset,
+      status: 'queued',
+      stage: 'queued',
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date('2026-04-01T00:00:00Z'),
+    } as IngestionJob);
+
+    ingestionStorageService.objectExists.mockResolvedValue(true);
+    visionOcrService.extractText.mockRejectedValue(
+      new Error('Vision quota exceeded'),
+    );
+
+    const result = await service.processNextQueuedJob();
+
+    expect(result).toEqual({
+      jobId: 'job-3',
+      status: 'failed',
+      stage: 'failed',
+      errorMessage: 'Vision quota exceeded',
+    });
+    expect(jobs.get('job-3')).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        errorMessage: 'Vision quota exceeded',
+      }),
+    );
+  });
+});

--- a/src/ingestion/worker/ingestion-worker.service.spec.ts
+++ b/src/ingestion/worker/ingestion-worker.service.spec.ts
@@ -102,6 +102,8 @@ describe('IngestionWorkerService', () => {
       sourceAsset,
       status: 'queued',
       stage: 'queued',
+      errorMessage: 'old error',
+      failedAt: new Date('2026-03-31T23:00:00Z'),
       createdAt: new Date('2026-04-01T00:00:00Z'),
       updatedAt: new Date('2026-04-01T00:00:00Z'),
     } as IngestionJob);
@@ -127,6 +129,8 @@ describe('IngestionWorkerService', () => {
         ocrProvider: 'google-vision',
         ocrText: 'Local band at Cat\'s Cradle',
         ocrConfidence: 0.91,
+        errorMessage: undefined,
+        failedAt: undefined,
       }),
     );
   });
@@ -168,6 +172,10 @@ describe('IngestionWorkerService', () => {
       sourceAsset,
       status: 'queued',
       stage: 'queued',
+      ocrProvider: 'google-vision',
+      ocrText: 'stale text',
+      ocrConfidence: 0.77,
+      completedAt: new Date('2026-04-01T01:00:00Z'),
       createdAt: new Date('2026-04-01T00:00:00Z'),
       updatedAt: new Date('2026-04-01T00:00:00Z'),
     } as IngestionJob);
@@ -189,7 +197,34 @@ describe('IngestionWorkerService', () => {
       expect.objectContaining({
         status: 'failed',
         errorMessage: 'Vision quota exceeded',
+        ocrProvider: undefined,
+        ocrText: undefined,
+        ocrConfidence: undefined,
+        completedAt: undefined,
       }),
     );
+  });
+
+  it('should not reprocess a job that is already in processing state', async () => {
+    jobs.set('job-4', {
+      id: 'job-4',
+      sourceAssetId: sourceAsset.id,
+      sourceAsset,
+      status: 'processing',
+      stage: 'ocr',
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date('2026-04-01T00:00:00Z'),
+    } as IngestionJob);
+
+    const result = await service.processJobById('job-4');
+
+    expect(result).toEqual({
+      jobId: 'job-4',
+      status: 'processing',
+      stage: 'ocr',
+      errorMessage: undefined,
+    });
+    expect(visionOcrService.extractText).not.toHaveBeenCalled();
+    expect(ingestionStorageService.objectExists).not.toHaveBeenCalled();
   });
 });

--- a/src/ingestion/worker/ingestion-worker.service.ts
+++ b/src/ingestion/worker/ingestion-worker.service.ts
@@ -1,0 +1,186 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { IngestionJob } from '../entities/ingestion-job.entity';
+import { IngestionStorageService } from '../storage/ingestion-storage.service';
+import { VisionOcrService } from '../ocr/vision-ocr.service';
+
+export interface ProcessedIngestionJobResult {
+  jobId: string;
+  status: string;
+  stage?: string;
+  errorMessage?: string;
+}
+
+@Injectable()
+export class IngestionWorkerService {
+  private readonly logger = new Logger(IngestionWorkerService.name);
+
+  constructor(
+    @InjectRepository(IngestionJob)
+    private readonly ingestionJobRepository: Repository<IngestionJob>,
+    private readonly ingestionStorageService: IngestionStorageService,
+    private readonly visionOcrService: VisionOcrService,
+  ) {}
+
+  async processNextQueuedJob(): Promise<ProcessedIngestionJobResult | null> {
+    const claimedJob = await this.claimNextQueuedJob();
+
+    if (!claimedJob) {
+      return null;
+    }
+
+    return this.processClaimedJob(claimedJob.id);
+  }
+
+  async processJobById(id: string): Promise<ProcessedIngestionJobResult> {
+    const claimedJob = await this.claimQueuedJobById(id);
+
+    if (claimedJob) {
+      return this.processClaimedJob(claimedJob.id);
+    }
+
+    const existingJob = await this.findJobById(id);
+
+    if (!existingJob) {
+      throw new NotFoundException(`Ingestion job ${id} not found`);
+    }
+
+    if (existingJob.status === 'processing') {
+      return this.processClaimedJob(existingJob.id);
+    }
+
+    return {
+      jobId: existingJob.id,
+      status: existingJob.status,
+      stage: existingJob.stage,
+      errorMessage: existingJob.errorMessage,
+    };
+  }
+
+  private async claimNextQueuedJob(): Promise<IngestionJob | null> {
+    const queuedJob = await this.ingestionJobRepository.findOne({
+      where: { status: 'queued' },
+      relations: { sourceAsset: true },
+      order: { createdAt: 'ASC' },
+    });
+
+    if (!queuedJob) {
+      return null;
+    }
+
+    const claimResult = await this.ingestionJobRepository.update(
+      { id: queuedJob.id, status: 'queued' },
+      {
+        status: 'processing',
+        stage: 'ocr',
+        processingStartedAt: new Date(),
+      },
+    );
+
+    if (!claimResult.affected) {
+      return null;
+    }
+
+    return this.findJobById(queuedJob.id);
+  }
+
+  private async claimQueuedJobById(id: string): Promise<IngestionJob | null> {
+    const claimResult = await this.ingestionJobRepository.update(
+      { id, status: 'queued' },
+      {
+        status: 'processing',
+        stage: 'ocr',
+        processingStartedAt: new Date(),
+      },
+    );
+
+    if (!claimResult.affected) {
+      return null;
+    }
+
+    return this.findJobById(id);
+  }
+
+  private async processClaimedJob(
+    id: string,
+  ): Promise<ProcessedIngestionJobResult> {
+    const job = await this.findJobById(id);
+
+    if (!job) {
+      throw new NotFoundException(`Ingestion job ${id} not found`);
+    }
+
+    if (!job.sourceAsset) {
+      return this.markFailed(job.id, 'Job is missing its linked source asset.');
+    }
+
+    try {
+      const objectExists = await this.ingestionStorageService.objectExists(
+        job.sourceAsset.bucket,
+        job.sourceAsset.objectName,
+      );
+
+      if (!objectExists) {
+        return this.markFailed(
+          job.id,
+          `Source asset gs://${job.sourceAsset.bucket}/${job.sourceAsset.objectName} was not found.`,
+        );
+      }
+
+      const ocrResult = await this.visionOcrService.extractText(
+        job.sourceAsset.bucket,
+        job.sourceAsset.objectName,
+      );
+
+      await this.ingestionJobRepository.update(job.id, {
+        status: 'parsed',
+        stage: 'parsed',
+        ocrProvider: ocrResult.provider,
+        ocrText: ocrResult.text,
+        ocrConfidence: ocrResult.confidence,
+        completedAt: new Date(),
+      });
+
+      this.logger.log(`Parsed ingestion job ${job.id}`);
+
+      return {
+        jobId: job.id,
+        status: 'parsed',
+        stage: 'parsed',
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown OCR worker failure.';
+      return this.markFailed(job.id, message);
+    }
+  }
+
+  private async markFailed(
+    jobId: string,
+    errorMessage: string,
+  ): Promise<ProcessedIngestionJobResult> {
+    await this.ingestionJobRepository.update(jobId, {
+      status: 'failed',
+      stage: 'failed',
+      errorMessage,
+      failedAt: new Date(),
+    });
+
+    this.logger.warn(`Failed ingestion job ${jobId}: ${errorMessage}`);
+
+    return {
+      jobId,
+      status: 'failed',
+      stage: 'failed',
+      errorMessage,
+    };
+  }
+
+  private async findJobById(id: string): Promise<IngestionJob | null> {
+    return this.ingestionJobRepository.findOne({
+      where: { id },
+      relations: { sourceAsset: true },
+    });
+  }
+}

--- a/src/ingestion/worker/ingestion-worker.service.ts
+++ b/src/ingestion/worker/ingestion-worker.service.ts
@@ -47,7 +47,12 @@ export class IngestionWorkerService {
     }
 
     if (existingJob.status === 'processing') {
-      return this.processClaimedJob(existingJob.id);
+      return {
+        jobId: existingJob.id,
+        status: existingJob.status,
+        stage: existingJob.stage,
+        errorMessage: existingJob.errorMessage,
+      };
     }
 
     return {
@@ -75,6 +80,12 @@ export class IngestionWorkerService {
         status: 'processing',
         stage: 'ocr',
         processingStartedAt: new Date(),
+        completedAt: undefined,
+        failedAt: undefined,
+        errorMessage: undefined,
+        ocrText: undefined,
+        ocrProvider: undefined,
+        ocrConfidence: undefined,
       },
     );
 
@@ -92,6 +103,12 @@ export class IngestionWorkerService {
         status: 'processing',
         stage: 'ocr',
         processingStartedAt: new Date(),
+        completedAt: undefined,
+        failedAt: undefined,
+        errorMessage: undefined,
+        ocrText: undefined,
+        ocrProvider: undefined,
+        ocrConfidence: undefined,
       },
     );
 
@@ -139,6 +156,8 @@ export class IngestionWorkerService {
         ocrProvider: ocrResult.provider,
         ocrText: ocrResult.text,
         ocrConfidence: ocrResult.confidence,
+        errorMessage: undefined,
+        failedAt: undefined,
         completedAt: new Date(),
       });
 
@@ -164,6 +183,10 @@ export class IngestionWorkerService {
       status: 'failed',
       stage: 'failed',
       errorMessage,
+      ocrText: undefined,
+      ocrProvider: undefined,
+      ocrConfidence: undefined,
+      completedAt: undefined,
       failedAt: new Date(),
     });
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,23 @@
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { IngestionWorkerRunner } from './ingestion/worker/ingestion-worker.runner';
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'error', 'warn'],
+  });
+
+  try {
+    const runner = app.get(IngestionWorkerRunner);
+    await runner.run();
+  } finally {
+    await app.close();
+  }
+}
+
+bootstrap().catch((error) => {
+  const logger = new Logger('IngestionWorkerBootstrap');
+  logger.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a separate worker runtime that polls queued ingestion jobs and runs Google Vision OCR
- persist OCR provider/text/confidence plus processing, completion, and failure timestamps on ingestion jobs
- add a direct `POST /ingestion/jobs` enqueue path, worker docs, and unit coverage for success + failure transitions

## Testing
- npm test -- --runInBand ingestion
- npm run build

## Notes
- This PR is stacked on top of #4 (`feature/ingestion-mvp`) because `main` does not yet contain the ingestion upload foundation.
- Local development can run the worker with `npm run start:worker:dev` or `npm run start:worker:once`.

Fixes #8
