### PR TITLE
feat: create parsed ingestion candidates from OCR output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ The ingestion flow now works in two phases:
 
 1. `POST /ingestion/uploads` stores the flyer image in GCS and creates a queued ingestion job.
 2. `POST /ingestion/jobs` can queue another OCR job for an existing uploaded asset owned by the current user.
-3. The worker process claims queued jobs, runs Google Vision OCR, and transitions jobs through `queued -> processing -> parsed` or `failed`.
+3. The worker process claims queued jobs, runs Google Vision OCR, parses draft event candidates, and transitions jobs through `queued -> processing -> needs_review` or `failed`.
+4. `GET /ingestion/jobs/:id` returns job state plus any generated candidate IDs/titles.
+5. `GET /ingestion/candidates/:id` returns the draft candidate detail for moderation/review tooling.
 
 Relevant env vars:
 

--- a/src/docs/WORKFLOW_PLAN.md
+++ b/src/docs/WORKFLOW_PLAN.md
@@ -1,148 +1,204 @@
-# Onboarding Flow Plan
+# NIDO API Workflow Plan
 
-## Learning Objectives
-- Who is responsible for what ( swim lanes)
+## Status
 
-## Tools used
-- draw
-- firebase auth
-- vs code or goose
-
-## Additonal resources too learn
-- draw.io
-- firebase auth
-- firestore
-- postgress
-
-# Workflow PLan
-
-## Authentication & User Bootstrap Flow
-
-### Status
-
-**Finalized (MVP v1)** – aligned with current architecture diagram and implementation plan.
+**Active roadmap (MVP platform build)** – updated to reflect the current backend direction.
 
 ---
 
-## Summary
+## Where the project is now
 
-This document describes the finalized **authentication and user bootstrap flow** for the Carolina Live Music ecosystem, powered by the open‑source **NIDO API**.
+The repo has moved beyond the original auth/bootstrap-only phase.
 
-The architecture is intentionally designed to:
+Implemented or in-flight backend slices now include:
+- Firebase-backed user auth/bootstrap
+- user profile sync/update basics
+- ingestion image upload to GCS
+- asynchronous OCR worker flow
+- parsed ingestion candidate generation for review
 
-- Use **Firebase Authentication** for identity and OAuth abstraction
-- Keep the **backend (NIDO API)** authoritative for domain users
-- Minimize database footprint for the MVP
-- Support web, mobile, and future AI/agent clients with the same flow
+That means the next planning layer is no longer “build concerts next.”
+The real platform path is now:
 
-This design is production‑sound while remaining cost‑effective and simple for early development.
-
----
-
-## Core Design Principles
-
-- **Identity ≠ Domain User**
-- **Clients are thin** (no business logic)
-- **Backend is deterministic**
-- **Auth is reusable across human and AI clients**
+**ingestion -> OCR -> candidate review -> canonical catalog -> partner/discovery APIs**
 
 ---
 
-## High-Level Components
+## Core Product Direction
 
-### Web App
+EZ Vibes needs a pipeline that can:
+1. accept raw event inputs (flyers, later partner submissions)
+2. convert them into reviewable draft records
+3. approve and normalize them into a canonical catalog
+4. expose approved events to end users and partners
 
-- Vue 3 + TypeScript
-- Uses Firebase Client SDK
-- Stores Firebase JWT in memory or secure client storage
-- Makes authenticated HTTP requests via Axios
-
-### Identity Providers
-
-- **Google Identity Platform** (OAuth)
-- **Firebase Authentication** (token verification + JWT issuance)
-
-### Backend API
-
-- **NIDO API (NestJS)**
-- Validates Firebase JWTs using Firebase Admin SDK
-- Owns domain user lifecycle
-- Exposes idempotent auth bootstrap endpoint (`POST /auth/sync`). This endpoint's job is to find a user based on the token, create one if they don't exist, and return the canonical user entity from Postgres.
-
-### Data Store
-
-- **Postgres** (domain users only)
-- Firebase Auth stores identity metadata
+For MVP, the system should prefer:
+- deterministic backend behavior
+- explicit provenance
+- moderate data quality over fake certainty
+- simple operational boundaries (API + worker)
 
 ---
 
-## Detailed User Signup Flow
+## Current Architecture Layers
 
-(Based on the diagram in `src/assets/FirebaseSignupFlow.jpg`)
+### 1. Identity and user layer
+- Firebase Authentication for identity
+- NestJS API for domain users
+- Postgres for application-owned records
 
-This flow outlines the precise sequence of events when a new user signs up.
+### 2. Ingestion layer
+- authenticated upload flow
+- source asset persistence
+- ingestion job tracking
+- async worker execution
 
-### Swim Lanes
-- **Web App:** The client-side application the user interacts with.
-- **Identity Providers:** Google Identity and Firebase Authentication.
-- **Nido API:** The backend application.
-- **Data Store:** The Postgres database.
+### 3. OCR + parsing layer
+- OCR reads uploaded flyer assets from GCS
+- OCR text persists on ingestion jobs
+- parser creates draft ingestion candidates
+- low-confidence or incomplete outputs remain in `needs_review`
 
-### Step-by-step Flow
-1.  **Web App:** User arrives on the Sign Up page.
-2.  **Web App:** User clicks "Sign Up with Google".
-3.  **Identity Providers:** The client redirects the user to Google Identity Platform for OAuth.
-4.  **Identity Providers:** Google authenticates the user and returns a Google ID Token.
-5.  **Identity Providers:** The Google ID Token is exchanged for a Firebase JWT.
-6.  **Web App:** The frontend receives the Firebase JWT and stores it in memory or secure storage.
-7.  **Web App & Nido API:** The frontend calls a `POST /auth/sync` endpoint on the Nido API, including the Firebase JWT in the authorization header.
-8.  **NIDO API:** The API validates the Firebase JWT using the Firebase Admin SDK. It then checks if a user record already exists in the database.
-9.  **NIDO API & Data Store:** If no user record is found, a new one is created in the Postgres database. The user's `email`, `picture`, and `uid` (Firebase ID) are extracted from the decoded JWT claims and mapped to the new user record.
-10. **NIDO API:** The user object (either found or newly created) is returned to the frontend.
-11. **Web App:** The user sees an "account created" confirmation and a welcome message.
+### 4. Review / moderation layer
+**Not implemented yet**
+- human/admin review of candidates
+- approve / reject / publish workflow
+- audit trail for candidate decisions
 
----
+### 5. Canonical catalog layer
+**Not implemented yet**
+- approved events
+- normalized venue/artist/source relationships
+- stable read APIs for discovery and partners
 
-## Core Implemented Patterns
-
-### @CurrentUser Decorator
-
-To streamline development and avoid repetitive database queries, a custom NestJS decorator, `@CurrentUser()`, has been implemented. This allows easy access to the fully populated Postgres `User` entity within any controller method.
-
-**Example Usage:**
-```typescript
-@Get('profile')
-getProfile(@CurrentUser() user: UserEntity) {
-  // 'user' is the full UserEntity object from Postgres
-  return user;
-}
-```
+### 6. Partner platform layer
+**Blocked on catalog + moderation foundations**
+- API-key auth
+- structured partner submissions
+- approved catalog sync endpoints
 
 ---
 
-## User Profile Management
+## MVP Build Sequence
 
-### Status: Implemented (MVP v1)
+### Phase 1 — Foundation
+Status: **partially complete**
+- Firebase auth bootstrap
+- domain user persistence
+- basic authenticated user flows
 
-A basic user profile page has been created to allow users to manage their data.
+### Phase 2 — Ingestion foundation
+Status: **complete / in review**
+- upload flyer images
+- persist source assets
+- create ingestion jobs
+- expose job lookup
 
-**Flow:**
-1.  **Web App:** After logging in, the user navigates to the `/profile` page.
-2.  **Web App:** The frontend uses the stored user state to display current information.
-3.  **Web App:** The user updates their name in an input field.
-4.  **Web App & Nido API:** On submission, the client sends a `PATCH /user` request with the updated name.
-5.  **NIDO API:** The backend receives the request, validates it, and updates the `name` field for the corresponding user in the Postgres database.
+### Phase 3 — OCR worker
+Status: **complete / in review**
+- background worker claims queued jobs
+- reads GCS object
+- runs Vision OCR
+- persists OCR output and failure state
+
+### Phase 4 — Candidate generation
+Status: **complete / in review**
+- deterministic parsing from OCR text
+- candidate persistence
+- candidate detail retrieval
+- jobs route to `needs_review`
+
+### Phase 5 — Moderation workflow
+Status: **next major blocker**
+Required capabilities:
+- moderation states for candidates
+- admin/reviewer endpoints
+- approve / reject / request-fix actions
+- publishing rules and audit trail
+
+### Phase 6 — Canonical event catalog
+Status: **blocked by moderation design**
+Required capabilities:
+- approved event model
+- source attribution model
+- normalized event/venue/artist strategy
+- read endpoints for approved catalog only
+
+### Phase 7 — Partner platform
+Status: **blocked by phases 5-6**
+Required capabilities:
+- partner identity and API keys
+- partner submissions
+- approved catalog sync (`updatedSince`)
+- source attribution via event sources
 
 ---
 
-## Next Steps: Concerts Feature
+## Immediate Engineering Priorities
 
-### Status: Planned
+### Priority 1
+Get ingestion PR stack merge-ready:
+- ingestion upload foundation
+- OCR worker
+- candidate generation
 
-The next major feature is to display a list of concerts relevant to the user on the homepage after they have logged in.
+### Priority 2
+Define moderation model:
+- candidate lifecycle states
+- reviewer actions
+- publish boundary between ingestion artifacts and canonical records
 
-**High-Level Plan:**
-1.  **Frontend:** Build out the `MyConcerts.vue` component to be a container for a list of concert cards.
-2.  **Backend:** Create a new module for Concerts (`/concerts`) with a controller, service, and entity.
-3.  **Backend:** Implement a `GET /concerts` endpoint that retrieves a list of concerts for the currently authenticated user.
-4.  **Frontend:** Update the `HomePage.vue` to call the `GET /concerts` endpoint and pass the data to the `MyConcerts.vue` component for rendering.
+### Priority 3
+Define canonical catalog schema:
+- canonical `events`
+- normalized venues/artists as needed
+- event provenance / source attribution
+
+### Priority 4
+Then implement partner APIs and discovery APIs on top of the approved catalog
+
+---
+
+## Major Known Blockers
+
+### Blocker A — Moderation workflow is missing
+Without moderation, the system can create draft candidates but cannot safely publish them.
+
+### Blocker B — Canonical catalog model is not defined
+Issue #12 and similar work depends on a stable approved event model.
+
+### Blocker C — Migration discipline is missing
+The project is adding entities/columns quickly, but there is not yet a clear migration workflow for persistent environments.
+
+### Blocker D — Operational docs are behind reality
+The old plan still points to user/concert flows instead of the ingestion pipeline now being built.
+
+---
+
+## Recommended Next Work After Current PR Stack
+
+1. Merge/finalize the ingestion stack
+2. Add moderation entities + admin review endpoints
+3. Define canonical approved event schema
+4. Add publish flow from candidate -> canonical event
+5. Then implement partner API slice (#12)
+
+---
+
+## Guardrails
+
+- Do not write parser output directly into canonical events
+- Do not let partner submissions bypass provenance or moderation
+- Keep Firebase auth separate from future partner API auth
+- Keep worker stages explicit (`queued`, `processing`, `parsing`, `needs_review`, `failed`, etc.)
+- Prefer deterministic parsing rules before LLM-assisted extraction
+
+---
+
+## Short version
+
+**What exists now:** auth + ingestion + OCR + candidate creation
+
+**What is missing next:** moderation + canonical catalog
+
+**What is blocked until then:** partner platform, approved catalog sync, broader discovery APIs

--- a/src/ingestion/entities/ingestion-candidate.entity.ts
+++ b/src/ingestion/entities/ingestion-candidate.entity.ts
@@ -1,0 +1,84 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { IngestionJob } from './ingestion-job.entity';
+import { SourceAsset } from './source-asset.entity';
+
+@Entity({ name: 'ingestion_candidates' })
+export class IngestionCandidate {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  ingestionJobId: string;
+
+  @ManyToOne(() => IngestionJob, (ingestionJob) => ingestionJob.candidates, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'ingestionJobId' })
+  ingestionJob: IngestionJob;
+
+  @Column()
+  sourceAssetId: string;
+
+  @ManyToOne(() => SourceAsset, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'sourceAssetId' })
+  sourceAsset: SourceAsset;
+
+  @Column({ default: 'needs_review' })
+  status: string;
+
+  @Column({ nullable: true })
+  title?: string;
+
+  @Column({ nullable: true, type: 'text' })
+  description?: string;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  startAt?: Date;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  endAt?: Date;
+
+  @Column({ nullable: true })
+  venueName?: string;
+
+  @Column({ nullable: true })
+  city?: string;
+
+  @Column({ nullable: true })
+  region?: string;
+
+  @Column({ nullable: true, type: 'simple-json' })
+  artistNames?: string[];
+
+  @Column({ nullable: true, type: 'simple-json' })
+  genreHints?: string[];
+
+  @Column({ nullable: true })
+  parserVersion?: string;
+
+  @Column({ nullable: true, type: 'float' })
+  parseConfidence?: number;
+
+  @Column({ nullable: true, type: 'simple-json' })
+  parseWarnings?: string[];
+
+  @Column({ nullable: true, type: 'simple-json' })
+  rawExtractedFields?: Record<string, unknown>;
+
+  @Column({ type: 'text' })
+  rawOcrText: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/ingestion/entities/ingestion-job.entity.ts
+++ b/src/ingestion/entities/ingestion-job.entity.ts
@@ -4,9 +4,11 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { IngestionCandidate } from './ingestion-candidate.entity';
 import { SourceAsset } from './source-asset.entity';
 
 @Entity({ name: 'ingestion_jobs' })
@@ -49,6 +51,9 @@ export class IngestionJob {
 
   @Column({ nullable: true, type: 'timestamptz' })
   failedAt?: Date;
+
+  @OneToMany(() => IngestionCandidate, (candidate) => candidate.ingestionJob)
+  candidates: IngestionCandidate[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/ingestion/ingestion.controller.spec.ts
+++ b/src/ingestion/ingestion.controller.spec.ts
@@ -5,6 +5,7 @@ describe('IngestionController', () => {
     uploadImage: jest.fn(),
     createJob: jest.fn(),
     getJob: jest.fn(),
+    getCandidate: jest.fn(),
   };
 
   let controller: IngestionController;
@@ -51,5 +52,16 @@ describe('IngestionController', () => {
     await controller.getJob('job-1', { uid: 'uid-1' } as any);
 
     expect(ingestionService.getJob).toHaveBeenCalledWith('job-1', 'uid-1');
+  });
+
+  it('should request a candidate lookup for the current user', async () => {
+    ingestionService.getCandidate.mockResolvedValue({ id: 'candidate-1' });
+
+    await controller.getCandidate('candidate-1', { uid: 'uid-1' } as any);
+
+    expect(ingestionService.getCandidate).toHaveBeenCalledWith(
+      'candidate-1',
+      'uid-1',
+    );
   });
 });

--- a/src/ingestion/ingestion.controller.ts
+++ b/src/ingestion/ingestion.controller.ts
@@ -56,4 +56,13 @@ export class IngestionController {
   ) {
     return this.ingestionService.getJob(id, user.uid);
   }
+
+  @Get('candidates/:id')
+  @UseGuards(FirebaseAuthGuard)
+  async getCandidate(
+    @Param('id') id: string,
+    @CurrentUser() user: DecodedIdToken,
+  ) {
+    return this.ingestionService.getCandidate(id, user.uid);
+  }
 }

--- a/src/ingestion/ingestion.module.ts
+++ b/src/ingestion/ingestion.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
+import { IngestionCandidate } from './entities/ingestion-candidate.entity';
 import { IngestionJob } from './entities/ingestion-job.entity';
 import { SourceAsset } from './entities/source-asset.entity';
 import { IngestionController } from './ingestion.controller';
 import { IngestionService } from './ingestion.service';
 import { VisionOcrService } from './ocr/vision-ocr.service';
+import { IngestionParserService } from './parser/ingestion-parser.service';
 import { IngestionStorageService } from './storage/ingestion-storage.service';
 import { IngestionWorkerRunner } from './worker/ingestion-worker.runner';
 import { IngestionWorkerService } from './worker/ingestion-worker.service';
@@ -15,13 +17,14 @@ import { IngestionWorkerService } from './worker/ingestion-worker.service';
   imports: [
     ConfigModule,
     AuthModule,
-    TypeOrmModule.forFeature([SourceAsset, IngestionJob]),
+    TypeOrmModule.forFeature([SourceAsset, IngestionJob, IngestionCandidate]),
   ],
   controllers: [IngestionController],
   providers: [
     IngestionService,
     IngestionStorageService,
     VisionOcrService,
+    IngestionParserService,
     IngestionWorkerService,
     IngestionWorkerRunner,
   ],

--- a/src/ingestion/ingestion.service.spec.ts
+++ b/src/ingestion/ingestion.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { NotFoundException } from '@nestjs/common';
+import { IngestionCandidate } from './entities/ingestion-candidate.entity';
 import { IngestionService } from './ingestion.service';
 import { SourceAsset } from './entities/source-asset.entity';
 import { IngestionJob } from './entities/ingestion-job.entity';
@@ -19,6 +20,10 @@ describe('IngestionService', () => {
   const ingestionJobRepository = {
     create: jest.fn(),
     save: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const ingestionCandidateRepository = {
     findOne: jest.fn(),
   };
 
@@ -53,6 +58,10 @@ describe('IngestionService', () => {
         {
           provide: getRepositoryToken(IngestionJob),
           useValue: ingestionJobRepository,
+        },
+        {
+          provide: getRepositoryToken(IngestionCandidate),
+          useValue: ingestionCandidateRepository,
         },
       ],
     }).compile();
@@ -145,5 +154,34 @@ describe('IngestionService', () => {
     await expect(
       service.createJob({ sourceAssetId: 'missing-asset' }, 'uid-1'),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('should return a candidate detail scoped to the owning user', async () => {
+    const candidate = {
+      id: 'candidate-1',
+      ingestionJobId: 'job-1',
+      sourceAssetId: 'asset-1',
+      status: 'needs_review',
+      title: 'THE HEADLINERS + DJ MOON',
+      artistNames: ['THE HEADLINERS', 'DJ MOON'],
+      rawOcrText: 'flyer text',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    ingestionCandidateRepository.findOne.mockResolvedValue(candidate);
+
+    const result = await service.getCandidate('candidate-1', 'uid-1');
+
+    expect(ingestionCandidateRepository.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'candidate-1',
+          sourceAsset: { uploadedByUid: 'uid-1' },
+        },
+      }),
+    );
+    expect(result.id).toBe('candidate-1');
+    expect(result.status).toBe('needs_review');
   });
 });

--- a/src/ingestion/ingestion.service.ts
+++ b/src/ingestion/ingestion.service.ts
@@ -9,9 +9,11 @@ import { extname } from 'path';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateIngestionJobDto } from './dto/create-ingestion-job.dto';
+import { IngestionCandidate } from './entities/ingestion-candidate.entity';
 import { CreateIngestionUploadDto } from './dto/create-ingestion-upload.dto';
 import { IngestionJob } from './entities/ingestion-job.entity';
 import { SourceAsset } from './entities/source-asset.entity';
+import { IngestionCandidateResponse } from './interfaces/ingestion-candidate-response.interface';
 import { IngestionJobResponse } from './interfaces/ingestion-job-response.interface';
 import { IngestionUploadResult } from './interfaces/ingestion-upload-result.interface';
 import { IngestionStorageService } from './storage/ingestion-storage.service';
@@ -28,6 +30,8 @@ export class IngestionService {
     private readonly sourceAssetRepository: Repository<SourceAsset>,
     @InjectRepository(IngestionJob)
     private readonly ingestionJobRepository: Repository<IngestionJob>,
+    @InjectRepository(IngestionCandidate)
+    private readonly ingestionCandidateRepository: Repository<IngestionCandidate>,
   ) {}
 
   async uploadImage(
@@ -138,7 +142,7 @@ export class IngestionService {
   async getJob(id: string, uid: string): Promise<IngestionJobResponse> {
     const job = await this.ingestionJobRepository.findOne({
       where: { id, sourceAsset: { uploadedByUid: uid } },
-      relations: { sourceAsset: true },
+      relations: { sourceAsset: true, candidates: true },
     });
 
     if (!job) {
@@ -146,6 +150,24 @@ export class IngestionService {
     }
 
     return this.toJobResponse(job);
+  }
+
+  async getCandidate(id: string, uid: string): Promise<IngestionCandidateResponse> {
+    const candidate = await this.ingestionCandidateRepository.findOne({
+      where: {
+        id,
+        sourceAsset: { uploadedByUid: uid },
+      },
+      relations: {
+        sourceAsset: true,
+      },
+    });
+
+    if (!candidate) {
+      throw new NotFoundException(`Ingestion candidate ${id} not found`);
+    }
+
+    return this.toCandidateResponse(candidate);
   }
 
   private toJobResponse(job: IngestionJob): IngestionJobResponse {
@@ -164,6 +186,12 @@ export class IngestionService {
       processingStartedAt: job.processingStartedAt,
       completedAt: job.completedAt,
       failedAt: job.failedAt,
+      candidates: job.candidates?.map((candidate) => ({
+        id: candidate.id,
+        status: candidate.status,
+        title: candidate.title,
+        parseConfidence: candidate.parseConfidence,
+      })),
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
       sourceAsset: {
@@ -179,6 +207,33 @@ export class IngestionService {
         uploadedByUid: job.sourceAsset.uploadedByUid,
         createdAt: job.sourceAsset.createdAt,
       },
+    };
+  }
+
+  private toCandidateResponse(
+    candidate: IngestionCandidate,
+  ): IngestionCandidateResponse {
+    return {
+      id: candidate.id,
+      ingestionJobId: candidate.ingestionJobId,
+      sourceAssetId: candidate.sourceAssetId,
+      status: candidate.status,
+      title: candidate.title,
+      description: candidate.description,
+      startAt: candidate.startAt,
+      endAt: candidate.endAt,
+      venueName: candidate.venueName,
+      city: candidate.city,
+      region: candidate.region,
+      artistNames: candidate.artistNames,
+      genreHints: candidate.genreHints,
+      parserVersion: candidate.parserVersion,
+      parseConfidence: candidate.parseConfidence,
+      parseWarnings: candidate.parseWarnings,
+      rawExtractedFields: candidate.rawExtractedFields,
+      rawOcrText: candidate.rawOcrText,
+      createdAt: candidate.createdAt,
+      updatedAt: candidate.updatedAt,
     };
   }
 

--- a/src/ingestion/interfaces/ingestion-candidate-response.interface.ts
+++ b/src/ingestion/interfaces/ingestion-candidate-response.interface.ts
@@ -1,0 +1,22 @@
+export interface IngestionCandidateResponse {
+  id: string;
+  ingestionJobId: string;
+  sourceAssetId: string;
+  status: string;
+  title?: string;
+  description?: string;
+  startAt?: Date;
+  endAt?: Date;
+  venueName?: string;
+  city?: string;
+  region?: string;
+  artistNames?: string[];
+  genreHints?: string[];
+  parserVersion?: string;
+  parseConfidence?: number;
+  parseWarnings?: string[];
+  rawExtractedFields?: Record<string, unknown>;
+  rawOcrText: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/ingestion/interfaces/ingestion-job-response.interface.ts
+++ b/src/ingestion/interfaces/ingestion-job-response.interface.ts
@@ -9,6 +9,12 @@ export interface IngestionJobResponse {
   processingStartedAt?: Date;
   completedAt?: Date;
   failedAt?: Date;
+  candidates?: Array<{
+    id: string;
+    status: string;
+    title?: string;
+    parseConfidence?: number;
+  }>;
   createdAt: Date;
   updatedAt: Date;
   sourceAsset: {

--- a/src/ingestion/parser/ingestion-parser.service.spec.ts
+++ b/src/ingestion/parser/ingestion-parser.service.spec.ts
@@ -1,0 +1,54 @@
+import { IngestionParserService } from './ingestion-parser.service';
+
+describe('IngestionParserService', () => {
+  let service: IngestionParserService;
+
+  beforeEach(() => {
+    service = new IngestionParserService();
+  });
+
+  it('should extract date, venue, city, artists, and genre hints from representative flyer text', () => {
+    const [candidate] = service.parseOcrText(`
+THE HEADLINERS + DJ MOON
+Friday April 17, 2026 8:00 PM
+at Cat's Cradle
+Carrboro, NC
+Indie rock dance party
+    `);
+
+    expect(candidate.title).toBe('THE HEADLINERS + DJ MOON');
+    expect(candidate.venueName).toBe("Cat's Cradle");
+    expect(candidate.city).toBe('Carrboro');
+    expect(candidate.region).toBe('NC');
+    expect(candidate.artistNames).toEqual(['THE HEADLINERS', 'DJ MOON']);
+    expect(candidate.genreHints).toEqual(expect.arrayContaining(['rock', 'indie', 'dj']));
+    expect(candidate.startAt).toBeInstanceOf(Date);
+    expect(candidate.parseWarnings).not.toContain('missing_start_date');
+  });
+
+  it('should handle numeric dates and partial extraction gracefully', () => {
+    const [candidate] = service.parseOcrText(`
+LATE NIGHT NOISE
+04/27/2026 9:30 PM
+Durham, NC
+    `);
+
+    expect(candidate.title).toBe('LATE NIGHT NOISE');
+    expect(candidate.city).toBe('Durham');
+    expect(candidate.region).toBe('NC');
+    expect(candidate.startAt).toBeInstanceOf(Date);
+    expect(candidate.parseWarnings).toContain('missing_venue');
+    expect(candidate.status).toBe('needs_review');
+  });
+
+  it('should fall back to source asset city when OCR text is sparse', () => {
+    const [candidate] = service.parseOcrText('Mystery Show', { city: 'Raleigh' });
+
+    expect(candidate.title).toBe('Mystery Show');
+    expect(candidate.city).toBe('Raleigh');
+    expect(candidate.parseWarnings).toEqual(
+      expect.arrayContaining(['missing_start_date', 'missing_venue']),
+    );
+    expect(candidate.parseConfidence).toBeGreaterThan(0);
+  });
+});

--- a/src/ingestion/parser/ingestion-parser.service.spec.ts
+++ b/src/ingestion/parser/ingestion-parser.service.spec.ts
@@ -23,6 +23,7 @@ Indie rock dance party
     expect(candidate.artistNames).toEqual(['THE HEADLINERS', 'DJ MOON']);
     expect(candidate.genreHints).toEqual(expect.arrayContaining(['rock', 'indie', 'dj']));
     expect(candidate.startAt).toBeInstanceOf(Date);
+    expect(candidate.startAt?.toISOString()).toBe('2026-04-17T20:00:00.000Z');
     expect(candidate.parseWarnings).not.toContain('missing_start_date');
   });
 
@@ -37,6 +38,7 @@ Durham, NC
     expect(candidate.city).toBe('Durham');
     expect(candidate.region).toBe('NC');
     expect(candidate.startAt).toBeInstanceOf(Date);
+    expect(candidate.startAt?.toISOString()).toBe('2026-04-27T21:30:00.000Z');
     expect(candidate.parseWarnings).toContain('missing_venue');
     expect(candidate.status).toBe('needs_review');
   });

--- a/src/ingestion/parser/ingestion-parser.service.ts
+++ b/src/ingestion/parser/ingestion-parser.service.ts
@@ -1,0 +1,238 @@
+import { Injectable } from '@nestjs/common';
+
+const GENRE_HINTS = [
+  'rock',
+  'indie',
+  'punk',
+  'metal',
+  'hip hop',
+  'rap',
+  'jazz',
+  'country',
+  'folk',
+  'pop',
+  'electronic',
+  'house',
+  'dj',
+];
+
+export const INGESTION_PARSER_VERSION = 'mvp-v1';
+
+export interface ParsedCandidateDraft {
+  status: string;
+  title?: string;
+  description?: string;
+  startAt?: Date;
+  endAt?: Date;
+  venueName?: string;
+  city?: string;
+  region?: string;
+  artistNames?: string[];
+  genreHints?: string[];
+  parserVersion: string;
+  parseConfidence: number;
+  parseWarnings: string[];
+  rawExtractedFields: Record<string, unknown>;
+  rawOcrText: string;
+}
+
+@Injectable()
+export class IngestionParserService {
+  parseOcrText(
+    ocrText: string,
+    context?: { city?: string },
+  ): ParsedCandidateDraft[] {
+    const normalizedText = ocrText.trim();
+    const lines = normalizedText
+      .split(/\r?\n/)
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .filter(Boolean);
+
+    const rawDateTime = this.extractDateTime(normalizedText);
+    const rawLocation = this.extractLocation(lines, context?.city);
+    const artistNames = this.extractArtists(lines, rawLocation.venueLine);
+    const genreHints = this.extractGenreHints(normalizedText);
+    const title = this.extractTitle(lines, rawLocation.venueLine);
+    const description = lines.slice(0, 6).join(' · ');
+
+    const warnings: string[] = [];
+
+    if (!title) warnings.push('missing_title');
+    if (!rawDateTime.startAt) warnings.push('missing_start_date');
+    if (!rawLocation.venueName) warnings.push('missing_venue');
+    if (!artistNames.length) warnings.push('missing_artists');
+    if (!rawLocation.city) warnings.push('missing_city');
+
+    const confidence = this.calculateConfidence({
+      title,
+      startAt: rawDateTime.startAt,
+      venueName: rawLocation.venueName,
+      city: rawLocation.city,
+      artistCount: artistNames.length,
+      genreCount: genreHints.length,
+    });
+
+    return [
+      {
+        status: 'needs_review',
+        title,
+        description,
+        startAt: rawDateTime.startAt,
+        endAt: rawDateTime.endAt,
+        venueName: rawLocation.venueName,
+        city: rawLocation.city,
+        region: rawLocation.region,
+        artistNames: artistNames.length ? artistNames : undefined,
+        genreHints: genreHints.length ? genreHints : undefined,
+        parserVersion: INGESTION_PARSER_VERSION,
+        parseConfidence: confidence,
+        parseWarnings: warnings,
+        rawExtractedFields: {
+          titleLine: title,
+          dateText: rawDateTime.dateText,
+          timeText: rawDateTime.timeText,
+          venueLine: rawLocation.venueLine,
+          cityLine: rawLocation.cityLine,
+          artistLine: rawLocation.artistLine,
+          matchedGenres: genreHints,
+          fallbackCity: context?.city,
+          sourceLines: lines,
+        },
+        rawOcrText: normalizedText,
+      },
+    ];
+  }
+
+  private extractTitle(lines: string[], venueLine?: string): string | undefined {
+    return lines.find(
+      (line) =>
+        line !== venueLine &&
+        !this.looksLikeDateOrTime(line) &&
+        !/^(doors|tickets|all ages|advance|show|doors open)\b/i.test(line),
+    );
+  }
+
+  private extractArtists(lines: string[], venueLine?: string): string[] {
+    const candidateLine = lines.find(
+      (line) =>
+        line !== venueLine &&
+        !this.looksLikeDateOrTime(line) &&
+        /,|\+|&|\bwith\b|\bw\/\b|\bfeat\b|\bft\b|\//i.test(line),
+    );
+
+    const sourceLine = candidateLine ?? lines[0] ?? '';
+    const artists = sourceLine
+      .split(/,|\+|&|\bwith\b|\bw\/\b|\bfeat\.?\b|\bft\.?\b|\//i)
+      .map((value) => value.trim())
+      .filter((value) => value.length > 1)
+      .slice(0, 8);
+
+    return [...new Set(artists)];
+  }
+
+  private extractGenreHints(text: string): string[] {
+    const lower = text.toLowerCase();
+    return GENRE_HINTS.filter((genre) => lower.includes(genre));
+  }
+
+  private extractLocation(lines: string[], fallbackCity?: string) {
+    const cityRegionMatch = lines
+      .map((line) => ({
+        line,
+        match: line.match(/\b([A-Za-z .'-]+),\s*([A-Z]{2})\b/),
+      }))
+      .find((item) => item.match);
+
+    const atLine = lines.find((line) => /(?:^|\s)(?:@|at)\s+/i.test(line));
+    const venueName = atLine
+      ? atLine.replace(/^.*?(?:@|at)\s+/i, '').trim()
+      : cityRegionMatch
+        ? lines[lines.indexOf(cityRegionMatch.line) - 1]
+        : undefined;
+
+    return {
+      venueName: venueName && !this.looksLikeDateOrTime(venueName) ? venueName : undefined,
+      venueLine: atLine ?? venueName,
+      city: cityRegionMatch?.match?.[1]?.trim() ?? fallbackCity,
+      region: cityRegionMatch?.match?.[2]?.trim(),
+      cityLine: cityRegionMatch?.line,
+      artistLine: lines.find((line) => /,|\+|&|\bwith\b|\bw\/\b|\bfeat\b|\bft\b|\//i.test(line)),
+    };
+  }
+
+  private extractDateTime(text: string) {
+    const monthMatch = text.match(
+      /\b(?:(Mon|Tue|Tues|Wed|Thu|Thurs|Fri|Sat|Sun)\.?\s+)?(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+(\d{1,2})(?:,\s*(\d{4}))?(?:[^\n\r\d]{0,12}(\d{1,2}(?::\d{2})?\s?(?:AM|PM)))?(?:\s*[-–]\s*(\d{1,2}(?::\d{2})?\s?(?:AM|PM)))?/i,
+    );
+
+    const numericMatch = text.match(
+      /\b(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?(?:[^\n\r\d]{0,12}(\d{1,2}(?::\d{2})?\s?(?:AM|PM)))?(?:\s*[-–]\s*(\d{1,2}(?::\d{2})?\s?(?:AM|PM)))?/i,
+    );
+
+    const year = new Date().getUTCFullYear();
+
+    if (monthMatch) {
+      const [, , month, day, providedYear, startTime, endTime] = monthMatch;
+      const dateLabel = `${month} ${day}, ${providedYear ?? year}`;
+      return {
+        dateText: dateLabel,
+        timeText: [startTime, endTime].filter(Boolean).join(' - ') || undefined,
+        startAt: this.buildDate(dateLabel, startTime),
+        endAt: this.buildDate(dateLabel, endTime),
+      };
+    }
+
+    if (numericMatch) {
+      const [, month, day, providedYear, startTime, endTime] = numericMatch;
+      const normalizedYear = providedYear
+        ? providedYear.length === 2
+          ? `20${providedYear}`
+          : providedYear
+        : String(year);
+      const dateLabel = `${month}/${day}/${normalizedYear}`;
+      return {
+        dateText: dateLabel,
+        timeText: [startTime, endTime].filter(Boolean).join(' - ') || undefined,
+        startAt: this.buildDate(dateLabel, startTime),
+        endAt: this.buildDate(dateLabel, endTime),
+      };
+    }
+
+    return {
+      dateText: undefined,
+      timeText: undefined,
+      startAt: undefined,
+      endAt: undefined,
+    };
+  }
+
+  private buildDate(dateLabel: string, timeLabel?: string): Date | undefined {
+    const composed = timeLabel ? `${dateLabel} ${timeLabel}` : dateLabel;
+    const parsed = new Date(composed);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+
+  private calculateConfidence(input: {
+    title?: string;
+    startAt?: Date;
+    venueName?: string;
+    city?: string;
+    artistCount: number;
+    genreCount: number;
+  }): number {
+    let score = 0.2;
+    if (input.title) score += 0.2;
+    if (input.startAt) score += 0.2;
+    if (input.venueName) score += 0.15;
+    if (input.city) score += 0.1;
+    if (input.artistCount) score += 0.1;
+    if (input.genreCount) score += 0.05;
+    return Number(Math.min(score, 0.99).toFixed(4));
+  }
+
+  private looksLikeDateOrTime(line: string): boolean {
+    return /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|mon|tue|wed|thu|fri|sat|sun|\d{1,2}:\d{2}|am|pm|\d{1,2}\/\d{1,2})\b/i.test(
+      line,
+    );
+  }
+}

--- a/src/ingestion/parser/ingestion-parser.service.ts
+++ b/src/ingestion/parser/ingestion-parser.service.ts
@@ -16,6 +16,33 @@ const GENRE_HINTS = [
   'dj',
 ];
 
+const MONTH_INDEX: Record<string, number> = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11,
+};
+
 export const INGESTION_PARSER_VERSION = 'mvp-v1';
 
 export interface ParsedCandidateDraft {
@@ -173,12 +200,24 @@ export class IngestionParserService {
 
     if (monthMatch) {
       const [, , month, day, providedYear, startTime, endTime] = monthMatch;
-      const dateLabel = `${month} ${day}, ${providedYear ?? year}`;
+      const normalizedYear = Number(providedYear ?? year);
       return {
-        dateText: dateLabel,
+        dateText: `${month} ${day}, ${normalizedYear}`,
         timeText: [startTime, endTime].filter(Boolean).join(' - ') || undefined,
-        startAt: this.buildDate(dateLabel, startTime),
-        endAt: this.buildDate(dateLabel, endTime),
+        startAt: this.buildDateFromParts(
+          normalizedYear,
+          this.getMonthIndex(month),
+          Number(day),
+          startTime,
+        ),
+        endAt: endTime
+          ? this.buildDateFromParts(
+              normalizedYear,
+              this.getMonthIndex(month),
+              Number(day),
+              endTime,
+            )
+          : undefined,
       };
     }
 
@@ -189,12 +228,24 @@ export class IngestionParserService {
           ? `20${providedYear}`
           : providedYear
         : String(year);
-      const dateLabel = `${month}/${day}/${normalizedYear}`;
+      const numericYear = Number(normalizedYear);
       return {
-        dateText: dateLabel,
+        dateText: `${month}/${day}/${numericYear}`,
         timeText: [startTime, endTime].filter(Boolean).join(' - ') || undefined,
-        startAt: this.buildDate(dateLabel, startTime),
-        endAt: this.buildDate(dateLabel, endTime),
+        startAt: this.buildDateFromParts(
+          numericYear,
+          Number(month) - 1,
+          Number(day),
+          startTime,
+        ),
+        endAt: endTime
+          ? this.buildDateFromParts(
+              numericYear,
+              Number(month) - 1,
+              Number(day),
+              endTime,
+            )
+          : undefined,
       };
     }
 
@@ -206,10 +257,56 @@ export class IngestionParserService {
     };
   }
 
-  private buildDate(dateLabel: string, timeLabel?: string): Date | undefined {
-    const composed = timeLabel ? `${dateLabel} ${timeLabel}` : dateLabel;
-    const parsed = new Date(composed);
+  private buildDateFromParts(
+    year: number,
+    monthIndex: number | undefined,
+    day: number,
+    timeLabel?: string,
+  ): Date | undefined {
+    if (
+      monthIndex === undefined ||
+      Number.isNaN(year) ||
+      Number.isNaN(day) ||
+      day < 1 ||
+      day > 31
+    ) {
+      return undefined;
+    }
+
+    const time = this.parseTime(timeLabel);
+    const parsed = new Date(
+      Date.UTC(year, monthIndex, day, time.hours, time.minutes, 0, 0),
+    );
+
     return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+
+  private getMonthIndex(month: string): number | undefined {
+    return MONTH_INDEX[month.toLowerCase()];
+  }
+
+  private parseTime(timeLabel?: string): { hours: number; minutes: number } {
+    if (!timeLabel) {
+      return { hours: 0, minutes: 0 };
+    }
+
+    const match = timeLabel.match(/^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)$/i);
+
+    if (!match) {
+      return { hours: 0, minutes: 0 };
+    }
+
+    let hours = Number(match[1]);
+    const minutes = Number(match[2] ?? '0');
+    const meridiem = match[3].toUpperCase();
+
+    if (meridiem === 'AM') {
+      hours = hours === 12 ? 0 : hours;
+    } else {
+      hours = hours === 12 ? 12 : hours + 12;
+    }
+
+    return { hours, minutes };
   }
 
   private calculateConfidence(input: {

--- a/src/ingestion/worker/ingestion-worker.service.spec.ts
+++ b/src/ingestion/worker/ingestion-worker.service.spec.ts
@@ -79,6 +79,14 @@ describe('IngestionWorkerService', () => {
 
   const ingestionCandidateRepository = {
     create: jest.fn((value: IngestionCandidate) => value),
+    delete: jest.fn(async (criteria: { ingestionJobId: string }) => {
+      const remaining = candidates.filter(
+        (candidate) => candidate.ingestionJobId !== criteria.ingestionJobId,
+      );
+      candidates.length = 0;
+      candidates.push(...remaining);
+      return { affected: 1 };
+    }),
     save: jest.fn(async (value: IngestionCandidate[]) => {
       candidates.push(...value);
       return value.map((candidate, index) => ({
@@ -173,6 +181,9 @@ describe('IngestionWorkerService', () => {
       }),
     );
     expect(candidates).toHaveLength(1);
+    expect(ingestionCandidateRepository.delete).toHaveBeenCalledWith({
+      ingestionJobId: 'job-1',
+    });
   });
 
   it('should mark a job failed when the source object is missing from GCS', async () => {
@@ -267,5 +278,52 @@ describe('IngestionWorkerService', () => {
     });
     expect(visionOcrService.extractText).not.toHaveBeenCalled();
     expect(ingestionStorageService.objectExists).not.toHaveBeenCalled();
+  });
+
+  it('should replace existing candidates when a job is reprocessed', async () => {
+    candidates.push({
+      id: 'candidate-old',
+      ingestionJobId: 'job-5',
+      sourceAssetId: sourceAsset.id,
+      sourceAsset,
+      status: 'needs_review',
+      title: 'old candidate',
+      rawOcrText: 'old',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as IngestionCandidate);
+
+    jobs.set('job-5', {
+      id: 'job-5',
+      sourceAssetId: sourceAsset.id,
+      sourceAsset,
+      status: 'queued',
+      stage: 'queued',
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date('2026-04-01T00:00:00Z'),
+    } as IngestionJob);
+
+    ingestionStorageService.objectExists.mockResolvedValue(true);
+    visionOcrService.extractText.mockResolvedValue({
+      provider: 'google-vision',
+      text: 'new flyer text',
+      confidence: 0.88,
+    });
+    ingestionParserService.parseOcrText.mockReturnValue([
+      {
+        status: 'needs_review',
+        title: 'new candidate',
+        parserVersion: 'mvp-v1',
+        parseConfidence: 0.88,
+        parseWarnings: [],
+        rawExtractedFields: {},
+        rawOcrText: 'new flyer text',
+      },
+    ]);
+
+    await service.processNextQueuedJob();
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].title).toBe('new candidate');
   });
 });

--- a/src/ingestion/worker/ingestion-worker.service.spec.ts
+++ b/src/ingestion/worker/ingestion-worker.service.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { IngestionCandidate } from '../entities/ingestion-candidate.entity';
 import { IngestionJob } from '../entities/ingestion-job.entity';
 import { SourceAsset } from '../entities/source-asset.entity';
 import { VisionOcrService } from '../ocr/vision-ocr.service';
+import { IngestionParserService } from '../parser/ingestion-parser.service';
 import { IngestionStorageService } from '../storage/ingestion-storage.service';
 import { IngestionWorkerService } from './ingestion-worker.service';
 
@@ -24,6 +26,7 @@ describe('IngestionWorkerService', () => {
   };
 
   const jobs = new Map<string, IngestionJob>();
+  const candidates: IngestionCandidate[] = [];
 
   const ingestionJobRepository = {
     findOne: jest.fn(async (options: any) => {
@@ -70,9 +73,25 @@ describe('IngestionWorkerService', () => {
     extractText: jest.fn(),
   };
 
+  const ingestionParserService = {
+    parseOcrText: jest.fn(),
+  };
+
+  const ingestionCandidateRepository = {
+    create: jest.fn((value: IngestionCandidate) => value),
+    save: jest.fn(async (value: IngestionCandidate[]) => {
+      candidates.push(...value);
+      return value.map((candidate, index) => ({
+        ...candidate,
+        id: candidate.id ?? `candidate-${index + 1}`,
+      }));
+    }),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     jobs.clear();
+    candidates.length = 0;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -82,6 +101,10 @@ describe('IngestionWorkerService', () => {
           useValue: ingestionJobRepository,
         },
         {
+          provide: getRepositoryToken(IngestionCandidate),
+          useValue: ingestionCandidateRepository,
+        },
+        {
           provide: IngestionStorageService,
           useValue: ingestionStorageService,
         },
@@ -89,13 +112,17 @@ describe('IngestionWorkerService', () => {
           provide: VisionOcrService,
           useValue: visionOcrService,
         },
+        {
+          provide: IngestionParserService,
+          useValue: ingestionParserService,
+        },
       ],
     }).compile();
 
     service = module.get<IngestionWorkerService>(IngestionWorkerService);
   });
 
-  it('should claim a queued job and transition it to parsed after OCR succeeds', async () => {
+  it('should claim a queued job and transition it to needs_review after OCR and parsing succeed', async () => {
     jobs.set('job-1', {
       id: 'job-1',
       sourceAssetId: sourceAsset.id,
@@ -114,17 +141,29 @@ describe('IngestionWorkerService', () => {
       text: 'Local band at Cat\'s Cradle',
       confidence: 0.91,
     });
+    ingestionParserService.parseOcrText.mockReturnValue([
+      {
+        status: 'needs_review',
+        title: 'Local band at Cat\'s Cradle',
+        artistNames: ['Local band'],
+        parserVersion: 'mvp-v1',
+        parseConfidence: 0.91,
+        parseWarnings: [],
+        rawExtractedFields: { cityLine: 'Carrboro, NC' },
+        rawOcrText: 'Local band at Cat\'s Cradle',
+      },
+    ]);
 
     const result = await service.processNextQueuedJob();
 
     expect(result).toEqual({
       jobId: 'job-1',
-      status: 'parsed',
+      status: 'needs_review',
       stage: 'parsed',
     });
     expect(jobs.get('job-1')).toEqual(
       expect.objectContaining({
-        status: 'parsed',
+        status: 'needs_review',
         stage: 'parsed',
         ocrProvider: 'google-vision',
         ocrText: 'Local band at Cat\'s Cradle',
@@ -133,6 +172,7 @@ describe('IngestionWorkerService', () => {
         failedAt: undefined,
       }),
     );
+    expect(candidates).toHaveLength(1);
   });
 
   it('should mark a job failed when the source object is missing from GCS', async () => {
@@ -184,6 +224,7 @@ describe('IngestionWorkerService', () => {
     visionOcrService.extractText.mockRejectedValue(
       new Error('Vision quota exceeded'),
     );
+    ingestionParserService.parseOcrText.mockReturnValue([]);
 
     const result = await service.processNextQueuedJob();
 

--- a/src/ingestion/worker/ingestion-worker.service.ts
+++ b/src/ingestion/worker/ingestion-worker.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { IngestionCandidate } from '../entities/ingestion-candidate.entity';
 import { IngestionJob } from '../entities/ingestion-job.entity';
+import { IngestionParserService } from '../parser/ingestion-parser.service';
 import { IngestionStorageService } from '../storage/ingestion-storage.service';
 import { VisionOcrService } from '../ocr/vision-ocr.service';
 
@@ -19,8 +21,11 @@ export class IngestionWorkerService {
   constructor(
     @InjectRepository(IngestionJob)
     private readonly ingestionJobRepository: Repository<IngestionJob>,
+    @InjectRepository(IngestionCandidate)
+    private readonly ingestionCandidateRepository: Repository<IngestionCandidate>,
     private readonly ingestionStorageService: IngestionStorageService,
     private readonly visionOcrService: VisionOcrService,
+    private readonly ingestionParserService: IngestionParserService,
   ) {}
 
   async processNextQueuedJob(): Promise<ProcessedIngestionJobResult | null> {
@@ -123,6 +128,7 @@ export class IngestionWorkerService {
     id: string,
   ): Promise<ProcessedIngestionJobResult> {
     const job = await this.findJobById(id);
+    let ocrSucceeded = false;
 
     if (!job) {
       throw new NotFoundException(`Ingestion job ${id} not found`);
@@ -151,43 +157,87 @@ export class IngestionWorkerService {
       );
 
       await this.ingestionJobRepository.update(job.id, {
-        status: 'parsed',
-        stage: 'parsed',
+        stage: 'parsing',
         ocrProvider: ocrResult.provider,
         ocrText: ocrResult.text,
         ocrConfidence: ocrResult.confidence,
+      });
+      ocrSucceeded = true;
+
+      const parsedCandidates = this.ingestionParserService.parseOcrText(ocrResult.text, {
+        city: job.sourceAsset.city,
+      });
+
+      const persistedCandidates = await this.ingestionCandidateRepository.save(
+        parsedCandidates.map((candidate) =>
+          this.ingestionCandidateRepository.create({
+            ingestionJobId: job.id,
+            ingestionJob: job,
+            sourceAssetId: job.sourceAssetId,
+            sourceAsset: job.sourceAsset,
+            status: candidate.status,
+            title: candidate.title,
+            description: candidate.description,
+            startAt: candidate.startAt,
+            endAt: candidate.endAt,
+            venueName: candidate.venueName,
+            city: candidate.city,
+            region: candidate.region,
+            artistNames: candidate.artistNames,
+            genreHints: candidate.genreHints,
+            parserVersion: candidate.parserVersion,
+            parseConfidence: candidate.parseConfidence,
+            parseWarnings: candidate.parseWarnings,
+            rawExtractedFields: candidate.rawExtractedFields,
+            rawOcrText: candidate.rawOcrText,
+          }),
+        ),
+      );
+
+      await this.ingestionJobRepository.update(job.id, {
+        status: persistedCandidates.length ? 'needs_review' : 'parsed',
+        stage: 'parsed',
         errorMessage: undefined,
         failedAt: undefined,
         completedAt: new Date(),
       });
 
-      this.logger.log(`Parsed ingestion job ${job.id}`);
+      this.logger.log(
+        `Parsed ingestion job ${job.id} and created ${persistedCandidates.length} candidate(s)`,
+      );
 
       return {
         jobId: job.id,
-        status: 'parsed',
+        status: persistedCandidates.length ? 'needs_review' : 'parsed',
         stage: 'parsed',
       };
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Unknown OCR worker failure.';
-      return this.markFailed(job.id, message);
+      return this.markFailed(job.id, message, {
+        preserveOcrFields: ocrSucceeded,
+      });
     }
   }
 
   private async markFailed(
     jobId: string,
     errorMessage: string,
+    options?: { preserveOcrFields?: boolean },
   ): Promise<ProcessedIngestionJobResult> {
     await this.ingestionJobRepository.update(jobId, {
       status: 'failed',
       stage: 'failed',
       errorMessage,
-      ocrText: undefined,
-      ocrProvider: undefined,
-      ocrConfidence: undefined,
       completedAt: undefined,
       failedAt: new Date(),
+      ...(options?.preserveOcrFields
+        ? {}
+        : {
+            ocrText: undefined,
+            ocrProvider: undefined,
+            ocrConfidence: undefined,
+          }),
     });
 
     this.logger.warn(`Failed ingestion job ${jobId}: ${errorMessage}`);

--- a/src/ingestion/worker/ingestion-worker.service.ts
+++ b/src/ingestion/worker/ingestion-worker.service.ts
@@ -168,6 +168,10 @@ export class IngestionWorkerService {
         city: job.sourceAsset.city,
       });
 
+      await this.ingestionCandidateRepository.delete({
+        ingestionJobId: job.id,
+      });
+
       const persistedCandidates = await this.ingestionCandidateRepository.save(
         parsedCandidates.map((candidate) =>
           this.ingestionCandidateRepository.create({


### PR DESCRIPTION
## Summary
- persist parsed ingestion candidates linked to ingestion jobs and source assets
- add a deterministic flyer parser plus worker integration so OCR jobs produce `needs_review` draft candidates
- expose candidate detail retrieval and include generated candidate summaries on job responses

## Testing
- npm test -- --runInBand ingestion
- npm run build

## Notes
- This PR is stacked on top of #15 because candidate creation depends on the async OCR worker branch.
- Parser output is intentionally best-effort and deterministic for MVP; low-confidence or incomplete drafts stay in `needs_review`.

Fixes #9
