### PR TITLE
Add Firebase and Cloud Run auto deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.agents
+client
+coverage
+dist
+docs
+node_modules
+test
+.env
+.env.*
+!.env.example
+firebase-creds.json
+nido-api-08fa5f15fac1.json
+firebase-debug.log
+npm-debug.log*
+.DS_Store

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "nido-api-9ed65"
+  }
+}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: firebase-hosting-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    env:
+      FIREBASE_PROJECT_ID: nido-api-9ed65
+      VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ vars.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
+      VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+      VITE_ADMIN_EMAILS: ${{ vars.VITE_ADMIN_EMAILS }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+
+      - name: Install API dependencies
+        run: npm ci
+
+      - name: Install client dependencies
+        run: npm ci --prefix client
+
+      - name: Test concert sync
+        run: npm test -- concert-sync
+
+      - name: Build API
+        run: npm run build
+
+      - name: Build client
+        run: npm run build --prefix client
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_NIDO_API_9ED65 }}
+
+      - name: Deploy Firebase Hosting
+        run: npx firebase-tools@latest deploy --only hosting --project "$FIREBASE_PROJECT_ID"

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Firebase Hosting
+name: Deploy Firebase and Cloud Run
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: firebase-hosting-main
+  group: firebase-cloud-run-main
   cancel-in-progress: true
 
 jobs:
@@ -18,7 +18,13 @@ jobs:
       contents: read
 
     env:
+      GCP_PROJECT_ID: nido-api-9ed65
       FIREBASE_PROJECT_ID: nido-api-9ed65
+      GAR_LOCATION: us-east1
+      GAR_REPOSITORY: nido
+      CLOUD_RUN_SERVICE: nido-api
+      CLOUD_RUN_REGION: us-east1
+      CORS_ORIGINS: ${{ vars.CORS_ORIGINS || 'https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com' }}
       VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
       VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
       VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
@@ -53,13 +59,60 @@ jobs:
       - name: Build API
         run: npm run build
 
-      - name: Build client
-        run: npm run build --prefix client
-
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_NIDO_API_9ED65 }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${GAR_LOCATION}-docker.pkg.dev" --quiet
+
+      - name: Ensure Artifact Registry repository exists
+        run: |
+          gcloud artifacts repositories describe "$GAR_REPOSITORY" \
+            --project "$GCP_PROJECT_ID" \
+            --location "$GAR_LOCATION" >/dev/null 2>&1 || \
+          gcloud artifacts repositories create "$GAR_REPOSITORY" \
+            --project "$GCP_PROJECT_ID" \
+            --location "$GAR_LOCATION" \
+            --repository-format docker \
+            --description "Nido API container images"
+
+      - name: Build API container
+        run: |
+          IMAGE="${GAR_LOCATION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GAR_REPOSITORY}/${CLOUD_RUN_SERVICE}:${GITHUB_SHA}"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+          docker build -t "$IMAGE" .
+
+      - name: Push API container
+        run: docker push "$IMAGE"
+
+      - name: Deploy API to Cloud Run
+        run: |
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$CLOUD_RUN_REGION" \
+            --platform managed \
+            --image "$IMAGE" \
+            --allow-unauthenticated \
+            --update-env-vars "^|^NODE_ENV=production|CORS_ORIGINS=${CORS_ORIGINS}"
+
+      - name: Resolve API URL for client build
+        run: |
+          API_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$CLOUD_RUN_REGION" \
+            --format 'value(status.url)')"
+          if [ -z "$VITE_API_BASE_URL" ]; then
+            echo "VITE_API_BASE_URL=$API_URL" >> "$GITHUB_ENV"
+          fi
+          echo "Cloud Run API URL: $API_URL"
+
+      - name: Build client
+        run: npm run build --prefix client
 
       - name: Deploy Firebase Hosting
         run: npx firebase-tools@latest deploy --only hosting --project "$FIREBASE_PROJECT_ID"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY nest-cli.json tsconfig*.json ./
+COPY src ./src
+RUN npm run build
+
+RUN npm prune --omit=dev
+
+FROM node:22-slim AS runner
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+
+EXPOSE 8080
+
+CMD ["node", "dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -126,9 +126,18 @@ Required env for AI enrichment:
   - `CONCERT_SYNC_MAX_DESCRIPTION_LENGTH`
   - `CONCERT_SYNC_MAX_EVENTS_PER_JOB` (defaults to 25, max 100)
 
+Required env for live Google Calendar sync:
+
+- Recommended deployed setup: create a Google service account, share the source calendar with the service account email, and grant `See all event details`.
+- Then configure one of:
+  - `GOOGLE_CALENDAR_SERVICE_ACCOUNT_JSON='{"client_email":"...","private_key":"..."}'`
+  - Or `GOOGLE_CALENDAR_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_CALENDAR_SERVICE_ACCOUNT_PRIVATE_KEY` (single-line key with `\n`)
+- Local/manual fallback: `GOOGLE_CALENDAR_ACCESS_TOKEN` or request-level `googleAccessToken`, but these are short-lived and not recommended for deployed demos.
+
 Important security behavior:
 
-- `googleAccessToken` is accepted per sync request and not persisted to the database.
+- Service-account credentials stay server-side; the client does not collect or transmit Google credentials.
+- `googleAccessToken` is accepted for Swagger/manual testing and is not persisted to the database.
 - Sync job records store operational metadata only (counts/status/extraction warnings).
 - Gemini prompt payload is sanitized before transmission (attendees/organizer omitted, emails/phones/URLs redacted).
 - Sync jobs record whether extraction used Gemini or fallback heuristics, including quota/billing fallback reasons.
@@ -150,6 +159,65 @@ Sample-job mode:
 
 - `POST /concert-sync/jobs` can accept `sampleEvents` for local/test runs without live Google API calls.
 - Production source of truth remains Google Calendar for now, but the sync service already isolates event-source loading (`loadSourceEvents`) so a future ingestion-pipeline source can be added without rewriting extraction/upsert logic.
+
+---
+
+## Deploy on Merge to Main
+
+This repo includes a GitHub Actions workflow at `.github/workflows/firebase-deploy.yml`.
+
+On every push to `main`, including a merged PR, the workflow:
+
+1. Installs API and client dependencies.
+2. Runs the concert sync test suite.
+3. Builds the Nest API.
+4. Builds and pushes an API Docker image to Artifact Registry.
+5. Deploys the API image to Cloud Run.
+6. Builds the Vue client with the deployed API URL.
+7. Deploys `client/dist` to Firebase Hosting.
+
+### Required GitHub Secret
+
+Create this repository secret:
+
+- `FIREBASE_SERVICE_ACCOUNT_NIDO_API_9ED65`
+
+The value should be the full JSON key for a Google service account that can deploy both Firebase Hosting and Cloud Run.
+
+Recommended IAM roles for the deploy service account:
+
+- Firebase Hosting Admin
+- Cloud Run Admin
+- Artifact Registry Admin, or Artifact Registry Writer if the `nido` repository already exists
+- Service Account User on the Cloud Run runtime service account
+
+### Required/Recommended GitHub Variables
+
+Client build variables:
+
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_STORAGE_BUCKET`
+- `VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `VITE_FIREBASE_APP_ID`
+- `VITE_ADMIN_EMAILS`
+
+Optional:
+
+- `VITE_API_BASE_URL`
+  - If omitted, the workflow uses the Cloud Run service URL after deploying the API.
+- `CORS_ORIGINS`
+  - Defaults to `https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com`.
+
+### Cloud Run Runtime Configuration
+
+The workflow deploys a new API container image and updates only:
+
+- `NODE_ENV=production`
+- `CORS_ORIGINS`
+
+Database credentials, Firebase Admin credentials, Google Calendar service account credentials, Gemini keys, and ingestion bucket config should be configured on the Cloud Run service as environment variables or Secret Manager references. The deploy intentionally does not overwrite those runtime settings.
 
 ## User Signup Flow
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,12 @@
+{
+  "hosting": {
+    "public": "client/dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,18 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe());
+  const allowedOrigins = (
+    process.env.CORS_ORIGINS ?? 'http://localhost:5173'
+  )
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
   app.enableCors({
-    origin: 'http://localhost:5173', // Allow only your frontend to access
+    origin: allowedOrigins,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: true, // Allow cookies/sessions if needed
+    credentials: true,
   });
 
   const swaggerConfig = new DocumentBuilder()


### PR DESCRIPTION
## Summary

Adds deployment automation separate from the Sync Doctor UI work.

- Adds Firebase Hosting configuration for the Vite client.
- Adds a GitHub Actions workflow that runs on pushes to `main`.
- Builds/tests the API, builds/pushes a Docker image, deploys the API to Cloud Run, builds the client with the Cloud Run API URL, and deploys Firebase Hosting.
- Adds Docker packaging for the Nest API.
- Makes API CORS configurable through `CORS_ORIGINS` for deployed frontend origins.
- Documents required GitHub secrets, repository variables, IAM roles, and Cloud Run runtime configuration.

## Validation

- `npm run build`
- `npm test -- concert-sync`
- `npm run build --prefix client`

## Setup Required Before Merge

Add repository secret:

- `FIREBASE_SERVICE_ACCOUNT_NIDO_API_9ED65`

Add repository variables for client build:

- `VITE_FIREBASE_API_KEY`
- `VITE_FIREBASE_AUTH_DOMAIN`
- `VITE_FIREBASE_PROJECT_ID`
- `VITE_FIREBASE_STORAGE_BUCKET`
- `VITE_FIREBASE_MESSAGING_SENDER_ID`
- `VITE_FIREBASE_APP_ID`
- `VITE_ADMIN_EMAILS`

Optional variables:

- `VITE_API_BASE_URL`
- `CORS_ORIGINS`

Cloud Run runtime env/secrets still need to be configured on the service for database, Firebase Admin, Google Calendar, Gemini, and GCS values.
