### PR TITLE
[codex] Harden Firebase Hosting deployment workflow

### DIFF
--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -27,6 +27,12 @@ The `github-deployer` service account is already configured with the following r
 - **Firebase Admin** (`roles/firebase.admin`) - to deploy resources to Firebase Hosting.
 - **Service Account User** (`roles/iam.serviceAccountUser`) on `nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com` - to deploy Cloud Run using that identity.
 
+### Firebase Hosting Auth
+
+Firebase Hosting deploys use the same Workload Identity Federation credentials as the Cloud Run deploy. The workflow does not use `FIREBASE_TOKEN`, `firebase login:ci`, or a checked-in service account JSON file.
+
+The `google-github-actions/auth` step writes an Application Default Credentials file and exposes it through `GOOGLE_APPLICATION_CREDENTIALS`. The Firebase CLI can use that credential directly in CI.
+
 ### Secret Manager Config
 
 Sensitive credentials remain stored in GCP Secret Manager. Do not store these in GitHub:
@@ -96,10 +102,9 @@ Repository:
 Settings -> Secrets and variables -> Actions
 ```
 
-Use:
+Use the `Variables` tab for all `VITE_*` values and `CORS_ORIGINS`.
 
-- `Secrets` tab for `GCP_DEPLOY_SERVICE_ACCOUNT_JSON`
-- `Variables` tab for all `VITE_*` values and `CORS_ORIGINS`
+Do not add a long-lived GCP service account JSON secret for this workflow unless WIF is intentionally being replaced.
 
 ## First Run
 

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -1,59 +1,399 @@
-# Dev Deployment GitHub Configuration
+# Nido Dev Deployment Reference
 
-This file documents the GitHub repository secret and variables required by:
+This guide documents the Nido dev deployment pipeline for `ezvibes/nido-api`.
+It is written as both an operating runbook and a reusable reference for deploying a
+Node API to Cloud Run and a Vite frontend to Firebase Hosting from GitHub Actions
+without long-lived Google Cloud keys.
+
+Workflow file:
 
 ```text
 .github/workflows/deploy-dev.yml
 ```
 
-The workflow deploys the API to Cloud Run and the frontend to Firebase Hosting after a merge to `main`, or manually through `workflow_dispatch`.
+Hosting REST deploy helper:
 
-## GitHub Authentication (Workload Identity Federation)
+```text
+.github/scripts/deploy-firebase-hosting.mjs
+```
 
-We use **Workload Identity Federation (WIF)** to securely authenticate the GitHub Actions pipeline with Google Cloud without using long-lived JSON key secrets.
+## Executive Summary
 
-The pipeline automatically connects using the OIDC provider:
-* **Workload Identity Provider**: `projects/81555493719/locations/global/workloadIdentityPools/github-pool/providers/github-provider`
-* **Deploy Service Account**: `github-deployer@nido-api-9ed65.iam.gserviceaccount.com`
+The pipeline uses GitHub Actions as the deployment orchestrator, Google Cloud
+Workload Identity Federation as the trust boundary, Cloud Run for the Nest API,
+Cloud SQL for PostgreSQL, Secret Manager for runtime secrets, Artifact Registry
+for container images, and Firebase Hosting for the Vue/Vite frontend.
 
-This setup allows the repository `ezvibes/nido-api` to assume the `github-deployer` service account to run the build and deploy.
+Important design choices:
 
-### Required Deploy-Time Permissions
+- GitHub Actions authenticates to Google Cloud with OIDC and Workload Identity Federation.
+- No long-lived deploy service account JSON is stored in GitHub.
+- API runtime secrets stay in Google Cloud Secret Manager.
+- Vite variables are treated as public browser configuration.
+- The API deploy is verified before the frontend is built and deployed.
+- Firebase Hosting is deployed through the Firebase Hosting REST API, not the Firebase CLI.
+- The frontend deploy reads `firebase.json` so Hosting config stays reviewable and versioned.
 
-The `github-deployer` service account is already configured with the following roles in project `nido-api-9ed65`:
+The current experiment branch validated this approach with a successful `Deploy Dev`
+workflow run on `2026-06-30`:
 
-- **Artifact Registry Writer** (`roles/artifactregistry.writer`) - to push Docker containers.
-- **Cloud Run Admin** (`roles/run.admin`) - to deploy/update the API service.
-- **Firebase Admin** (`roles/firebase.admin`) - to deploy resources to Firebase Hosting.
-- **Service Account User** (`roles/iam.serviceAccountUser`) on `nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com` - to deploy Cloud Run using that identity.
+```text
+Run: 28413477405
+Branch: codex/firebase-hosting-wif-experiment
+Commit: 39ca998398ceaa6d368c493ae858ba84614d624a
+Result: success
+Duration: 3m17s
+```
 
-### Firebase Hosting Deploy
+## Architecture
 
-Firebase Hosting deploys use the same Workload Identity Federation credentials as the Cloud Run deploy. The workflow does not use `FIREBASE_TOKEN`, `firebase login:ci`, the Firebase CLI, or a checked-in service account JSON file.
+```text
+GitHub Actions
+  |
+  | OIDC token
+  v
+Google Workload Identity Federation
+  |
+  | impersonates
+  v
+github-deployer@nido-api-9ed65.iam.gserviceaccount.com
+  |
+  | pushes image, deploys service, gets short-lived OAuth token
+  v
+Artifact Registry + Cloud Run + Firebase Hosting REST API
 
-The workflow gets a short-lived OAuth access token from `gcloud auth print-access-token` after WIF authentication, then runs `.github/scripts/deploy-firebase-hosting.mjs`. That script reads `firebase.json` and deploys the configured Hosting public directory through the Firebase Hosting REST API:
+Cloud Run runtime:
+  nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
+  |
+  | reads runtime secrets and connects to Cloud SQL
+  v
+Secret Manager + Cloud SQL
+```
 
-- create a Hosting version
-- hash and upload required files
-- finalize the version with the SPA rewrite config
-- release the version to the `live` channel
+## Live Dev Resources
 
-### Secret Manager Config
+Project:
 
-Sensitive credentials remain stored in GCP Secret Manager. Do not store these in GitHub:
+```text
+nido-api-9ed65
+```
 
-- `nido-db-password`
-- `nido-firebase-private-key`
-- `nido-gemini-api-key`
-- `nido-google-calendar-private-key`
+Region:
 
----
+```text
+us-east1
+```
 
-## Required GitHub Variables
+Live URLs:
 
-Use `.github/deploy-dev.env.example` as the source of truth for variable names.
+- Frontend: https://nido-api-9ed65.web.app
+- Alternate frontend domain: https://nido-api-9ed65.firebaseapp.com
+- API: https://nido-api-81555493719.us-east1.run.app
+- Swagger UI: https://nido-api-81555493719.us-east1.run.app/api-docs
+- OpenAPI JSON: https://nido-api-81555493719.us-east1.run.app/api-docs-json
 
-Required variables:
+Core resources:
+
+```text
+Cloud Run service: nido-api
+Cloud SQL instance: nido-postgres-dev
+Cloud SQL database: nido
+Cloud SQL user: nido_api
+Cloud SQL connection: nido-api-9ed65:us-east1:nido-postgres-dev
+Artifact Registry repo: us-east1/nido
+Firebase Hosting site: nido-api-9ed65
+Runtime service account: nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
+Deploy service account: github-deployer@nido-api-9ed65.iam.gserviceaccount.com
+```
+
+## Pipeline Sequence
+
+The `Deploy Dev` workflow runs on:
+
+- pushes to `main`
+- manual `workflow_dispatch`
+
+The job sequence is intentionally ordered to fail fast before expensive deploy work:
+
+1. Check out the repository.
+2. Derive deployment values such as the Cloud SQL connection name and image tag.
+3. Validate required GitHub repository variables.
+4. Set up Node with npm cache for API and client lockfiles.
+5. Install API dependencies with `npm ci`.
+6. Install client dependencies with `npm ci --prefix client`.
+7. Run focused API tests.
+8. Build the API as a fast pre-Docker validation gate.
+9. Authenticate to Google Cloud through Workload Identity Federation.
+10. Install/configure `gcloud`.
+11. Configure Docker for Artifact Registry.
+12. Set up Docker Buildx.
+13. Build and push a `linux/amd64` API container to Artifact Registry.
+14. Deploy the API image to Cloud Run.
+15. Resolve the Cloud Run URL.
+16. Verify `/health`, `/health/deep`, and `/api-docs-json`.
+17. Build the client with the verified API URL available to Vite.
+18. Deploy Firebase Hosting through the REST API.
+19. Verify Firebase Hosting responds.
+
+Why the frontend build happens after API verification:
+
+- If `VITE_API_BASE_URL` is not set, the workflow resolves the deployed Cloud Run URL and injects it before building.
+- A frontend deploy should not publish a UI pointed at an API revision that failed health checks.
+
+Why the Docker build happens after local API build/tests:
+
+- Docker build/push is one of the slower stages.
+- Local tests and API build catch common issues before pushing an image.
+- The Dockerfile still builds the API independently, preserving image reproducibility.
+
+## GitHub Actions Configuration
+
+### Permissions
+
+The job uses minimum required GitHub token permissions:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+`id-token: write` is required for GitHub OIDC. `contents: read` is enough for checkout.
+
+### Concurrency
+
+The workflow uses branch-aware concurrency:
+
+```yaml
+concurrency:
+  group: deploy-dev-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+This cancels stale deploys for the same ref without letting an experiment branch cancel a
+`main` deploy.
+
+### Action Versions
+
+The workflow should stay on current major versions of core actions to avoid runtime
+deprecation warnings and receive maintained defaults:
+
+```yaml
+actions/checkout@v7
+actions/setup-node@v6
+google-github-actions/auth@v3
+google-github-actions/setup-gcloud@v3
+docker/setup-buildx-action@v4
+docker/build-push-action@v7
+```
+
+### Docker Build Cache
+
+Docker Buildx uses GitHub Actions cache:
+
+```yaml
+cache-from: type=gha
+cache-to: type=gha,mode=max
+```
+
+The first run may not be faster because it seeds the cache. Later runs can reuse
+unchanged Docker layers.
+
+## Authentication Model
+
+### Workload Identity Federation
+
+The workflow authenticates through Google Cloud Workload Identity Federation:
+
+```yaml
+- name: Authenticate to Google Cloud
+  uses: google-github-actions/auth@v3
+  with:
+    workload_identity_provider: projects/81555493719/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+    service_account: github-deployer@nido-api-9ed65.iam.gserviceaccount.com
+```
+
+This lets GitHub Actions impersonate the deploy service account with short-lived
+credentials. It avoids storing long-lived service account JSON in GitHub.
+
+Do not add a `GCP_DEPLOY_SERVICE_ACCOUNT_JSON` secret unless the project intentionally
+abandons WIF.
+
+### Deploy Service Account
+
+Deploy identity:
+
+```text
+github-deployer@nido-api-9ed65.iam.gserviceaccount.com
+```
+
+Required capabilities:
+
+- Push Docker images to Artifact Registry.
+- Deploy/update Cloud Run service `nido-api`.
+- Act as the runtime service account for Cloud Run deploys.
+- Deploy Firebase Hosting through the Firebase Hosting REST API.
+
+Current role shape:
+
+- `roles/artifactregistry.writer`
+- `roles/run.admin`
+- `roles/firebase.admin`
+- `roles/iam.serviceAccountUser` on `nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com`
+
+Hardening target:
+
+- Replace broad project-level roles with resource-level grants where practical.
+- Keep `roles/iam.serviceAccountUser` scoped to the runtime service account.
+- Consider custom Firebase Hosting deploy permissions after the REST deploy path is stable.
+
+### Runtime Service Account
+
+Runtime identity:
+
+```text
+nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
+```
+
+Required capabilities:
+
+- Connect to Cloud SQL.
+- Read required runtime secrets.
+- Write ingestion objects to the dev GCS bucket.
+
+Current role shape:
+
+- `roles/cloudsql.client`
+- `roles/secretmanager.secretAccessor`
+- `roles/storage.objectAdmin` on `gs://nido-concert-image-ingestion-dev`
+
+Hardening target:
+
+- Scope Secret Manager access to specific secrets instead of project-wide access.
+- Consider narrower storage permissions if ingestion only needs a subset of object operations.
+
+## API Deployment
+
+The API image tag is tied to the Git commit:
+
+```text
+us-east1-docker.pkg.dev/nido-api-9ed65/nido/nido-api:${GITHUB_SHA}
+```
+
+The workflow builds for Cloud Run's expected platform:
+
+```yaml
+platforms: linux/amd64
+```
+
+Cloud Run environment uses delimiter-based `--set-env-vars` syntax because several
+values contain commas:
+
+```bash
+RUN_ENVS="^|^NODE_ENV=production|DB_HOST=/cloudsql/${SQL_CONNECTION}|..."
+```
+
+Cloud Run runtime secrets are mapped from Secret Manager:
+
+```text
+DB_PASSWORD=nido-db-password:latest
+FIREBASE_PRIVATE_KEY=nido-firebase-private-key:latest
+GEMINI_API_KEY=nido-gemini-api-key:latest
+GOOGLE_CALENDAR_SERVICE_ACCOUNT_PRIVATE_KEY=nido-google-calendar-private-key:latest
+```
+
+Runtime database posture:
+
+```text
+DB_SYNCHRONIZE=false
+DB_MIGRATIONS_RUN=true
+```
+
+Production hardening:
+
+- Keep `DB_SYNCHRONIZE=false`.
+- Prefer explicit migrations.
+- Verify migrations are idempotent and logged.
+
+## Firebase Hosting REST Deployment
+
+The CI path intentionally does not use:
+
+- Firebase CLI
+- `FIREBASE_TOKEN`
+- `firebase login:ci`
+- service account JSON secrets
+
+Reason:
+
+- Firebase CLI auth failed in GitHub Actions with WIF-generated external credentials.
+- `FIREBASE_TOKEN` is deprecated by Firebase CLI.
+- REST deployment can use the same short-lived OAuth access token that already works for GCP calls.
+
+The workflow gets a token after WIF authentication:
+
+```bash
+FIREBASE_ACCESS_TOKEN="$(gcloud auth print-access-token)" \
+  node .github/scripts/deploy-firebase-hosting.mjs
+```
+
+The REST deploy script performs the Firebase Hosting API sequence:
+
+1. Read `firebase.json`.
+2. Resolve the Hosting public directory.
+3. Convert supported Hosting config into REST API config.
+4. Gzip every static file and compute SHA-256 hashes.
+5. Create a Hosting version.
+6. Call `:populateFiles` with the file manifest.
+7. Upload only hashes Firebase reports as missing.
+8. Finalize the Hosting version with config.
+9. Release the version to the `live` channel.
+
+Current supported Hosting config:
+
+- `public`
+- destination `rewrites`
+- `redirects`
+- `headers`
+- `source`, `glob`, or `regex` patterns
+
+Current project config:
+
+```json
+{
+  "hosting": {
+    "public": "client/dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}
+```
+
+Dry-run validation:
+
+```bash
+FIREBASE_HOSTING_DRY_RUN=true node .github/scripts/deploy-firebase-hosting.mjs
+```
+
+Expected output shape:
+
+```text
+Preparing Firebase Hosting deploy for site nido-api-9ed65.
+Found 4 file(s) in client/dist.
+Prepared 4 Hosting manifest entrie(s).
+Dry run complete. No Firebase Hosting version was created.
+```
+
+## GitHub Repository Variables
+
+Use GitHub repository variables for browser-visible build configuration.
+
+Required:
 
 ```text
 VITE_FIREBASE_API_KEY
@@ -65,22 +405,23 @@ VITE_FIREBASE_APP_ID
 VITE_ADMIN_EMAILS
 ```
 
-Recommended optional variables:
+Recommended optional:
 
 ```text
 VITE_API_BASE_URL
 CORS_ORIGINS
 ```
 
-If `VITE_API_BASE_URL` is omitted, the workflow resolves the Cloud Run URL after the API deploy and uses that URL for the frontend build.
+If `VITE_API_BASE_URL` is omitted, the workflow resolves the deployed Cloud Run URL and
+sets it before the client build.
 
-If `CORS_ORIGINS` is omitted, the workflow defaults to:
+Default CORS origins:
 
 ```text
 https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com,http://localhost:5173
 ```
 
-### Set Variables With GitHub CLI
+Set variables with GitHub CLI:
 
 ```bash
 gh variable set VITE_API_BASE_URL --body "https://nido-api-81555493719.us-east1.run.app"
@@ -88,7 +429,7 @@ gh variable set CORS_ORIGINS --body "https://nido-api-9ed65.web.app,https://nido
 gh variable set VITE_ADMIN_EMAILS --body "ezvibesinc@gmail.com"
 gh variable set VITE_FIREBASE_AUTH_DOMAIN --body "nido-api-9ed65.firebaseapp.com"
 gh variable set VITE_FIREBASE_PROJECT_ID --body "nido-api-9ed65"
-gh variable set VITE_FIREBASE_STORAGE_BUCKET --body "nido-api-9ed65.firebasestorage.app"
+gh variable set VITE_FIREBASE_STORAGE_BUCKET --body "nido-api-9ed65.appspot.com"
 ```
 
 Set these from the Firebase Web App config:
@@ -99,38 +440,187 @@ gh variable set VITE_FIREBASE_MESSAGING_SENDER_ID --body "<firebase-messaging-se
 gh variable set VITE_FIREBASE_APP_ID --body "<firebase-web-app-id>"
 ```
 
-## GitHub UI Path
-
-Repository:
+GitHub UI path:
 
 ```text
-Settings -> Secrets and variables -> Actions
+Settings -> Secrets and variables -> Actions -> Variables
 ```
 
-Use the `Variables` tab for all `VITE_*` values and `CORS_ORIGINS`.
+Do not put private keys, database passwords, Firebase Admin credentials, or Gemini keys
+in GitHub variables. Vite variables are browser-visible after build.
 
-Do not add a long-lived GCP service account JSON secret for this workflow unless WIF is intentionally being replaced.
+## Secret Manager
 
-## First Run
+Sensitive backend values remain in Google Cloud Secret Manager:
 
-After the PR is merged and config is set:
+```text
+nido-db-password
+nido-firebase-private-key
+nido-gemini-api-key
+nido-google-calendar-private-key
+```
 
-1. Open GitHub Actions.
-2. Select `Deploy Dev`.
-3. Run manually once with `workflow_dispatch`, or push/merge to `main`.
-4. Confirm these steps pass:
-   - API tests
-   - API build
-   - Docker build/push
-   - Cloud Run deploy
-   - `/health`
-   - `/health/deep`
-   - `/api-docs-json`
-   - client build
-   - Firebase Hosting deploy
+Do not store these in GitHub Actions secrets unless there is a clear, reviewed reason.
+The deployed Cloud Run service reads them at runtime through Secret Manager bindings.
 
-## Live Dev URLs
+## First-Time Setup Checklist
 
-- Frontend: https://nido-api-9ed65.web.app
-- API: https://nido-api-81555493719.us-east1.run.app
-- Swagger: https://nido-api-81555493719.us-east1.run.app/api-docs
+1. Confirm required Google APIs are enabled:
+   - Cloud Run API
+   - Artifact Registry API
+   - Cloud SQL Admin API
+   - Secret Manager API
+   - Firebase Hosting API
+2. Confirm Artifact Registry repo exists:
+   - `us-east1/nido`
+3. Confirm Cloud SQL instance and database exist:
+   - `nido-postgres-dev`
+   - `nido`
+4. Confirm runtime service account exists.
+5. Confirm deploy service account exists.
+6. Confirm Workload Identity Pool and provider are configured for `ezvibes/nido-api`.
+7. Confirm deploy service account IAM roles.
+8. Confirm runtime service account IAM roles.
+9. Confirm required Secret Manager secrets and versions.
+10. Confirm GitHub repository variables.
+11. Run `Deploy Dev` manually from the experiment branch.
+12. Merge only after the manual run is green.
+
+## Routine Deploy Checklist
+
+Before merge:
+
+```bash
+npm test -- user.service health.service concert-sync
+npm run build
+npm run build --prefix client
+FIREBASE_HOSTING_DRY_RUN=true node .github/scripts/deploy-firebase-hosting.mjs
+```
+
+After merge or manual dispatch, confirm these GitHub Actions steps pass:
+
+- Validate deploy configuration
+- Run focused API tests
+- Build API
+- Authenticate to Google Cloud
+- Build and push API container
+- Deploy API to Cloud Run
+- Verify API health
+- Build client
+- Deploy Firebase Hosting
+- Verify Firebase Hosting
+
+Live smoke checks:
+
+```bash
+curl -fsS https://nido-api-81555493719.us-east1.run.app/health
+curl -fsS https://nido-api-81555493719.us-east1.run.app/health/deep
+curl -fsS https://nido-api-81555493719.us-east1.run.app/api-docs-json >/dev/null
+curl -fsSI https://nido-api-9ed65.web.app >/dev/null
+```
+
+## Troubleshooting
+
+### GitHub Actions Fails Before Google Auth
+
+Likely causes:
+
+- Missing repository variables.
+- Invalid workflow syntax.
+- npm install failure.
+- focused test failure.
+
+The `Validate deploy configuration` step should catch missing frontend variables before
+Docker/GCP work begins.
+
+### WIF Authentication Fails
+
+Check:
+
+- `permissions.id-token` is set to `write`.
+- Repository owner/name matches the WIF provider attribute condition.
+- The deploy service account allows impersonation from the GitHub principal set.
+- `workload_identity_provider` points at the correct project number, pool, and provider.
+
+### Docker Push Fails
+
+Check:
+
+- `gcloud auth configure-docker "${REGION}-docker.pkg.dev"` ran successfully.
+- Deploy service account can write to the Artifact Registry repo.
+- Image path uses the correct project, region, repo, and service name.
+
+### Cloud Run Deploy Fails
+
+Check:
+
+- Deploy service account has Cloud Run deploy permissions.
+- Deploy service account has `iam.serviceAccountUser` on the runtime service account.
+- Runtime service account exists.
+- Secret names referenced by `--set-secrets` exist.
+- Cloud SQL connection name is correct.
+
+### API Health Fails After Deploy
+
+Check:
+
+- Cloud Run logs for Nest startup errors.
+- TypeORM migration output.
+- Cloud SQL connectivity.
+- Secret Manager access denials.
+- `DB_MIGRATIONS_RUN=true` migration failures.
+
+### Firebase Hosting REST Deploy Fails
+
+Check:
+
+- `gcloud auth print-access-token` succeeds after WIF auth.
+- Deploy service account has Firebase Hosting deployment permissions.
+- Firebase Hosting API is enabled.
+- `firebase.json` only uses Hosting config supported by `.github/scripts/deploy-firebase-hosting.mjs`.
+- `client/dist` exists and contains built files.
+
+If the API returns a JSON error, the REST deploy script prints the HTTP status and response
+body. That is the primary diagnostic artifact.
+
+### Firebase Hosting Verifies But UI Looks Stale
+
+Check:
+
+- The client build ran after `VITE_API_BASE_URL` was resolved.
+- Browser cache or service worker is not serving an old asset.
+- The Hosting release in Firebase console points at the latest version.
+- `client/dist/index.html` includes the build timestamp comment appended by the workflow.
+
+## Audit Findings And Current Posture
+
+What is strong:
+
+- WIF avoids long-lived deploy keys.
+- Runtime secrets are in Secret Manager, not GitHub.
+- API deploy is health-checked before frontend deploy.
+- Docker images are commit-addressable by SHA.
+- Branch-aware concurrency prevents experiment runs from canceling `main`.
+- REST Hosting deploy avoids deprecated Firebase token flows.
+- Local dry-run covers Hosting config parsing and manifest generation.
+
+What should be hardened next:
+
+- Scope Secret Manager access to specific secrets.
+- Replace broad Firebase Admin deploy permission with narrower custom permissions if practical.
+- Add a full smoke-test script that checks authenticated flows when a test token is available.
+- Split CI validation from deployment if the repo grows, so pull requests can run fast non-deploy checks.
+- Add Artifact Registry cleanup policy for old SHA images.
+- Add Cloud Run revision retention/cost review to the monthly runbook.
+
+## Source References
+
+- Firebase Hosting REST API deployment guide: https://firebase.google.com/docs/hosting/api-deploy
+- Firebase CLI reference and CI auth context: https://firebase.google.com/docs/cli
+- Google GitHub Actions auth action: https://github.com/google-github-actions/auth
+- Google GitHub Actions setup-gcloud action: https://github.com/google-github-actions/setup-gcloud
+- GitHub Actions OIDC security hardening: https://docs.github.com/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+- GitHub Actions workflow syntax and permissions: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions
+- Docker Buildx GitHub Actions cache: https://docs.docker.com/build/ci/github-actions/cache/
+- Cloud Run deploy with gcloud: https://cloud.google.com/run/docs/deploying
+- Cloud Run service identity: https://cloud.google.com/run/docs/securing/service-identity

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -11,6 +11,12 @@ Workflow file:
 .github/workflows/deploy-dev.yml
 ```
 
+Pull request validation workflow:
+
+```text
+.github/workflows/validate-deployment.yml
+```
+
 Hosting REST deploy helper:
 
 ```text
@@ -30,12 +36,12 @@ Important design choices:
 - No long-lived deploy service account JSON is stored in GitHub.
 - API runtime secrets stay in Google Cloud Secret Manager.
 - Vite variables are treated as public browser configuration.
-- The API deploy is verified before the frontend is built and deployed.
+- The API and frontend builds both pass before any deployment mutates dev infrastructure.
+- The API deploy is verified before Firebase Hosting is released.
 - Firebase Hosting is deployed through the Firebase Hosting REST API, not the Firebase CLI.
 - The frontend deploy reads `firebase.json` so Hosting config stays reviewable and versioned.
 
-The current experiment branch validated this approach with a successful `Deploy Dev`
-workflow run on `2026-06-30`:
+Initial validation snapshot for this approach:
 
 ```text
 Run: 28413924740
@@ -113,6 +119,11 @@ The `Deploy Dev` workflow runs on:
 - pushes to `main`
 - manual `workflow_dispatch`
 
+The `Validate Deployment` workflow runs on:
+
+- pull requests that touch deployment, API, or client build inputs
+- manual `workflow_dispatch`
+
 The job sequence is intentionally ordered to fail fast before expensive deploy work:
 
 1. Check out the repository.
@@ -125,20 +136,22 @@ The job sequence is intentionally ordered to fail fast before expensive deploy w
 8. Build the API as a fast pre-Docker validation gate.
 9. Authenticate to Google Cloud through Workload Identity Federation.
 10. Install/configure `gcloud`.
-11. Configure Docker for Artifact Registry.
-12. Set up Docker Buildx.
-13. Build and push a `linux/amd64` API container to Artifact Registry.
-14. Deploy the API image to Cloud Run.
-15. Resolve the Cloud Run URL.
-16. Verify `/health`, `/health/deep`, and `/api-docs-json`.
-17. Build the client with the verified API URL available to Vite.
-18. Deploy Firebase Hosting through the REST API.
-19. Verify Firebase Hosting responds.
+11. Resolve the client API base URL if `VITE_API_BASE_URL` is not configured.
+12. Build the client before mutating Cloud Run or Firebase Hosting.
+13. Configure Docker for Artifact Registry.
+14. Set up Docker Buildx.
+15. Build and push a `linux/amd64` API container to Artifact Registry.
+16. Deploy the API image to Cloud Run.
+17. Resolve the deployed Cloud Run URL for health checks.
+18. Verify `/health`, `/health/deep`, and `/api-docs-json`.
+19. Deploy Firebase Hosting through the REST API.
+20. Verify Firebase Hosting responds.
 
-Why the frontend build happens after API verification:
+Why the frontend build happens before API deployment:
 
-- If `VITE_API_BASE_URL` is not set, the workflow resolves the deployed Cloud Run URL and injects it before building.
-- A frontend deploy should not publish a UI pointed at an API revision that failed health checks.
+- A broken frontend build should stop the release before Cloud Run changes.
+- If `VITE_API_BASE_URL` is not set, the workflow resolves the current Cloud Run service URL and injects it before building.
+- The API deploy is still health-checked before Firebase Hosting is released, preventing a new UI from being published against an unhealthy API revision.
 
 Why the Docker build happens after local API build/tests:
 
@@ -342,16 +355,18 @@ The REST deploy script performs the Firebase Hosting API sequence:
 1. Read `firebase.json`.
 2. Resolve the Hosting public directory.
 3. Convert supported Hosting config into REST API config.
-4. Gzip every static file and compute SHA-256 hashes.
-5. Create a Hosting version.
-6. Call `:populateFiles` with the file manifest.
-7. Upload only hashes Firebase reports as missing.
-8. Finalize the Hosting version with config.
-9. Release the version to the `live` channel.
+4. Apply `firebase.json` Hosting ignore patterns to the public directory.
+5. Gzip every static file and compute SHA-256 hashes.
+6. Create a Hosting version.
+7. Call `:populateFiles` with the file manifest in bounded batches.
+8. Upload only hashes Firebase reports as missing for each returned upload URL.
+9. Finalize the Hosting version with config.
+10. Release the version to the `live` channel.
 
 Current supported Hosting config:
 
 - `public`
+- `ignore`
 - destination `rewrites`
 - `redirects`
 - `headers`
@@ -385,6 +400,7 @@ Expected output shape:
 ```text
 Preparing Firebase Hosting deploy for site nido-api-9ed65.
 Found 4 file(s) in client/dist.
+Applied 3 firebase.json ignore pattern(s).
 Prepared 4 Hosting manifest entrie(s).
 Dry run complete. No Firebase Hosting version was created.
 ```
@@ -483,8 +499,9 @@ The deployed Cloud Run service reads them at runtime through Secret Manager bind
 8. Confirm runtime service account IAM roles.
 9. Confirm required Secret Manager secrets and versions.
 10. Confirm GitHub repository variables.
-11. Run `Deploy Dev` manually from the experiment branch.
-12. Merge only after the manual run is green.
+11. Confirm `Validate Deployment` is green on the pull request.
+12. Run `Deploy Dev` manually from the experiment branch when validating deployment changes.
+13. Merge only after validation and any required manual deploy run are green.
 
 ## Routine Deploy Checklist
 
@@ -503,10 +520,12 @@ After merge or manual dispatch, confirm these GitHub Actions steps pass:
 - Run focused API tests
 - Build API
 - Authenticate to Google Cloud
+- Resolve client API base URL
+- Build client
 - Build and push API container
 - Deploy API to Cloud Run
+- Resolve deployed Cloud Run API URL
 - Verify API health
-- Build client
 - Deploy Firebase Hosting
 - Verify Firebase Hosting
 
@@ -598,18 +617,19 @@ What is strong:
 
 - WIF avoids long-lived deploy keys.
 - Runtime secrets are in Secret Manager, not GitHub.
-- API deploy is health-checked before frontend deploy.
+- API and client builds gate deployment before infrastructure changes.
+- API deploy is health-checked before Firebase Hosting release.
 - Docker images are commit-addressable by SHA.
 - Branch-aware concurrency prevents experiment runs from canceling `main`.
 - REST Hosting deploy avoids deprecated Firebase token flows.
-- Local dry-run covers Hosting config parsing and manifest generation.
+- Pull request validation covers API tests, API build, client build, and Hosting REST dry-run.
+- Local dry-run covers Hosting config parsing, ignore handling, and manifest generation.
 
 What should be hardened next:
 
 - Scope Secret Manager access to specific secrets.
 - Replace broad Firebase Admin deploy permission with narrower custom permissions if practical.
 - Add a full smoke-test script that checks authenticated flows when a test token is available.
-- Split CI validation from deployment if the repo grows, so pull requests can run fast non-deploy checks.
 - Add Artifact Registry cleanup policy for old SHA images.
 - Add Cloud Run revision retention/cost review to the monthly runbook.
 

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -38,11 +38,11 @@ The current experiment branch validated this approach with a successful `Deploy 
 workflow run on `2026-06-30`:
 
 ```text
-Run: 28413477405
+Run: 28413924740
 Branch: codex/firebase-hosting-wif-experiment
-Commit: 39ca998398ceaa6d368c493ae858ba84614d624a
+Commit: 02c6b98a573e01abde1ab27ee274395b5650ac5a
 Result: success
-Duration: 3m17s
+Duration: 1m26s
 ```
 
 ## Architecture

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -27,11 +27,16 @@ The `github-deployer` service account is already configured with the following r
 - **Firebase Admin** (`roles/firebase.admin`) - to deploy resources to Firebase Hosting.
 - **Service Account User** (`roles/iam.serviceAccountUser`) on `nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com` - to deploy Cloud Run using that identity.
 
-### Firebase Hosting Auth
+### Firebase Hosting Deploy
 
-Firebase Hosting deploys use the same Workload Identity Federation credentials as the Cloud Run deploy. The workflow does not use `FIREBASE_TOKEN`, `firebase login:ci`, or a checked-in service account JSON file.
+Firebase Hosting deploys use the same Workload Identity Federation credentials as the Cloud Run deploy. The workflow does not use `FIREBASE_TOKEN`, `firebase login:ci`, the Firebase CLI, or a checked-in service account JSON file.
 
-The `google-github-actions/auth` step writes an Application Default Credentials file and exposes it through `GOOGLE_APPLICATION_CREDENTIALS`. The Firebase CLI can use that credential directly in CI.
+The workflow gets a short-lived OAuth access token from `gcloud auth print-access-token` after WIF authentication, then runs `.github/scripts/deploy-firebase-hosting.mjs`. That script reads `firebase.json` and deploys the configured Hosting public directory through the Firebase Hosting REST API:
+
+- create a Hosting version
+- hash and upload required files
+- finalize the version with the SPA rewrite config
+- release the version to the `live` channel
 
 ### Secret Manager Config
 

--- a/.github/deploy-dev.env.example
+++ b/.github/deploy-dev.env.example
@@ -19,5 +19,6 @@ VITE_FIREBASE_STORAGE_BUCKET=nido-api-9ed65.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=<firebase-messaging-sender-id>
 VITE_FIREBASE_APP_ID=<firebase-web-app-id>
 
-# Required GitHub repository secret, not a variable:
-# GCP_DEPLOY_SERVICE_ACCOUNT_JSON=<full deploy service account JSON>
+# This workflow authenticates to Google Cloud and Firebase Hosting with
+# Workload Identity Federation. Do not add a long-lived deploy service account
+# JSON secret unless the workflow is intentionally moved away from WIF.

--- a/.github/scripts/deploy-firebase-hosting.mjs
+++ b/.github/scripts/deploy-firebase-hosting.mjs
@@ -1,0 +1,284 @@
+import { createHash } from 'node:crypto';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const {
+  FIREBASE_ACCESS_TOKEN,
+  FIREBASE_PROJECT_ID = 'nido-api-9ed65',
+  FIREBASE_HOSTING_SITE = FIREBASE_PROJECT_ID,
+  FIREBASE_HOSTING_CHANNEL = 'live',
+  FIREBASE_HOSTING_PUBLIC_DIR,
+  FIREBASE_HOSTING_DRY_RUN,
+  GITHUB_SHA = 'local',
+} = process.env;
+
+const dryRun = FIREBASE_HOSTING_DRY_RUN === 'true';
+
+if (!FIREBASE_ACCESS_TOKEN && !dryRun) {
+  throw new Error('FIREBASE_ACCESS_TOKEN is required.');
+}
+
+const apiBase = 'https://firebasehosting.googleapis.com/v1beta1';
+const populateBatchSize = 1000;
+const uploadConcurrency = 20;
+
+async function firebaseRequest(url, options = {}) {
+  if (!FIREBASE_ACCESS_TOKEN) {
+    throw new Error('FIREBASE_ACCESS_TOKEN is required.');
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${FIREBASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`${options.method ?? 'GET'} ${url} failed with ${response.status}: ${body}`);
+  }
+
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  return response.json();
+}
+
+async function readHostingConfig() {
+  const firebaseConfig = JSON.parse(await readFile('firebase.json', 'utf8'));
+  const hosting = Array.isArray(firebaseConfig.hosting)
+    ? firebaseConfig.hosting.find((config) => config.site === FIREBASE_HOSTING_SITE) ?? firebaseConfig.hosting[0]
+    : firebaseConfig.hosting;
+
+  if (!hosting) {
+    throw new Error('firebase.json does not contain a hosting config.');
+  }
+
+  return {
+    publicDir: path.resolve(FIREBASE_HOSTING_PUBLIC_DIR ?? hosting.public ?? 'public'),
+    config: convertHostingConfig(hosting),
+  };
+}
+
+function convertHostingConfig(hosting) {
+  const config = {};
+
+  if (hosting.rewrites) {
+    config.rewrites = hosting.rewrites.map((rewrite) => {
+      if (!rewrite.destination) {
+        throw new Error('REST deploy script currently supports destination rewrites only.');
+      }
+
+      return {
+        ...convertPattern(rewrite),
+        path: rewrite.destination,
+      };
+    });
+  }
+
+  if (hosting.redirects) {
+    config.redirects = hosting.redirects.map((redirect) => ({
+      ...convertPattern(redirect),
+      location: redirect.destination,
+      ...(redirect.type ? { statusCode: redirect.type } : {}),
+    }));
+  }
+
+  if (hosting.headers) {
+    config.headers = hosting.headers.map((header) => ({
+      ...convertPattern(header),
+      headers: Object.fromEntries((header.headers ?? []).map(({ key, value }) => [key, value])),
+    }));
+  }
+
+  return config;
+}
+
+function convertPattern(entry) {
+  if (entry.source) {
+    return { glob: entry.source };
+  }
+  if (entry.glob) {
+    return { glob: entry.glob };
+  }
+  if (entry.regex) {
+    return { regex: entry.regex };
+  }
+  throw new Error('Hosting config entry is missing source, glob, or regex.');
+}
+
+async function walk(dir, root = dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(fullPath, root));
+    } else if (entry.isFile()) {
+      files.push(path.relative(root, fullPath).split(path.sep).join('/'));
+    }
+  }
+
+  return files.sort();
+}
+
+function hostingPath(filePath) {
+  return `/${filePath}`;
+}
+
+async function buildManifest(files, publicDir) {
+  const manifest = {};
+  const uploads = new Map();
+
+  for (const filePath of files) {
+    const absolutePath = path.join(publicDir, filePath);
+    const source = await readFile(absolutePath);
+    const gzipped = gzipSync(source, { level: 9 });
+    const hash = createHash('sha256').update(gzipped).digest('hex');
+    const stats = await stat(absolutePath);
+
+    manifest[hostingPath(filePath)] = hash;
+    uploads.set(hash, { filePath, gzipped, size: stats.size });
+  }
+
+  return { manifest, uploads };
+}
+
+function chunk(items, size) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+async function uploadRequiredFiles(versionName, manifest, uploads) {
+  const populateUrl = `${apiBase}/${versionName}:populateFiles`;
+  const requiredHashes = new Set();
+  let uploadUrl;
+
+  for (const entries of chunk(Object.entries(manifest), populateBatchSize)) {
+    const populate = await firebaseRequest(populateUrl, {
+      method: 'POST',
+      body: JSON.stringify({ files: Object.fromEntries(entries) }),
+    });
+
+    uploadUrl = populate.uploadUrl;
+    for (const hash of populate.uploadRequiredHashes ?? []) {
+      requiredHashes.add(hash);
+    }
+  }
+
+  console.log(`Firebase Hosting requires ${requiredHashes.size} file upload(s).`);
+
+  if (!uploadUrl && requiredHashes.size > 0) {
+    throw new Error('Firebase did not return an upload URL.');
+  }
+
+  const uploadOne = async (hash) => {
+    const upload = uploads.get(hash);
+    if (!upload) {
+      throw new Error(`Firebase requested unknown file hash ${hash}.`);
+    }
+
+    const response = await fetch(`${uploadUrl}/${hash}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${FIREBASE_ACCESS_TOKEN}`,
+        'Content-Type': 'application/octet-stream',
+      },
+      body: upload.gzipped,
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Upload failed for ${upload.filePath} (${hash}) with ${response.status}: ${body}`);
+    }
+  };
+
+  const pending = [...requiredHashes];
+  const workers = Array.from({ length: Math.min(uploadConcurrency, pending.length) }, async () => {
+    while (pending.length > 0) {
+      const hash = pending.shift();
+      await uploadOne(hash);
+    }
+  });
+
+  await Promise.all(workers);
+}
+
+async function main() {
+  const { publicDir, config } = await readHostingConfig();
+  const files = await walk(publicDir);
+  if (files.length === 0) {
+    throw new Error(`No files found in ${path.relative(process.cwd(), publicDir)}.`);
+  }
+
+  const publicDirLabel = path.relative(process.cwd(), publicDir) || publicDir;
+
+  console.log(`Preparing Firebase Hosting deploy for site ${FIREBASE_HOSTING_SITE}.`);
+  console.log(`Found ${files.length} file(s) in ${publicDirLabel}.`);
+
+  const { manifest, uploads } = await buildManifest(files, publicDir);
+  console.log(`Prepared ${Object.keys(manifest).length} Hosting manifest entrie(s).`);
+
+  if (dryRun) {
+    console.log('Dry run complete. No Firebase Hosting version was created.');
+    return;
+  }
+
+  const version = await firebaseRequest(
+    `${apiBase}/projects/-/sites/${FIREBASE_HOSTING_SITE}/versions`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        status: 'CREATED',
+        labels: {
+          'deployment-tool': 'github-actions-rest',
+          'github-sha': GITHUB_SHA.slice(0, 40),
+        },
+      }),
+    },
+  );
+
+  const versionName = version.name;
+  const versionId = versionName.split('/').at(-1);
+  console.log(`Created Hosting version ${versionName}.`);
+
+  await uploadRequiredFiles(versionName, manifest, uploads);
+
+  await firebaseRequest(
+    `${apiBase}/projects/-/sites/${FIREBASE_HOSTING_SITE}/versions/${versionId}?updateMask=status,config`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({
+        status: 'FINALIZED',
+        config,
+      }),
+    },
+  );
+  console.log(`Finalized Hosting version ${versionName}.`);
+
+  const release = await firebaseRequest(
+    `${apiBase}/projects/-/sites/${FIREBASE_HOSTING_SITE}/channels/${FIREBASE_HOSTING_CHANNEL}/releases?versionName=${encodeURIComponent(versionName)}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        message: `GitHub Actions deploy ${GITHUB_SHA.slice(0, 12)}`,
+      }),
+    },
+  );
+
+  console.log(`Released Firebase Hosting version: ${release.name}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/.github/scripts/deploy-firebase-hosting.mjs
+++ b/.github/scripts/deploy-firebase-hosting.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { gzipSync } from 'node:zlib';
 
@@ -141,10 +141,9 @@ async function buildManifest(files, publicDir) {
     const source = await readFile(absolutePath);
     const gzipped = gzipSync(source, { level: 9 });
     const hash = createHash('sha256').update(gzipped).digest('hex');
-    const stats = await stat(absolutePath);
 
     manifest[hostingPath(filePath)] = hash;
-    uploads.set(hash, { filePath, gzipped, size: stats.size });
+    uploads.set(hash, { filePath, gzipped });
   }
 
   return { manifest, uploads };

--- a/.github/scripts/deploy-firebase-hosting.mjs
+++ b/.github/scripts/deploy-firebase-hosting.mjs
@@ -61,6 +61,7 @@ async function readHostingConfig() {
 
   return {
     publicDir: path.resolve(FIREBASE_HOSTING_PUBLIC_DIR ?? hosting.public ?? 'public'),
+    ignore: hosting.ignore ?? [],
     config: convertHostingConfig(hosting),
   };
 }
@@ -112,6 +113,45 @@ function convertPattern(entry) {
   throw new Error('Hosting config entry is missing source, glob, or regex.');
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function globToRegExp(pattern) {
+  let source = '^';
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        const afterGlobstar = pattern[index + 2];
+        if (afterGlobstar === '/') {
+          source += '(?:.*\\/)?';
+          index += 2;
+        } else {
+          source += '.*';
+          index += 1;
+        }
+      } else {
+        source += '[^/]*';
+      }
+    } else {
+      source += escapeRegExp(char);
+    }
+  }
+
+  source += '$';
+  return new RegExp(source);
+}
+
+function createIgnoreMatcher(ignorePatterns) {
+  const matchers = ignorePatterns.map((pattern) => globToRegExp(pattern));
+
+  return (filePath) => matchers.some((matcher) => matcher.test(filePath));
+}
+
 async function walk(dir, root = dir) {
   const entries = await readdir(dir, { withFileTypes: true });
   const files = [];
@@ -126,6 +166,15 @@ async function walk(dir, root = dir) {
   }
 
   return files.sort();
+}
+
+function filterIgnoredFiles(files, ignorePatterns) {
+  if (ignorePatterns.length === 0) {
+    return files;
+  }
+
+  const isIgnored = createIgnoreMatcher(ignorePatterns);
+  return files.filter((filePath) => !isIgnored(filePath));
 }
 
 function hostingPath(filePath) {
@@ -159,8 +208,7 @@ function chunk(items, size) {
 
 async function uploadRequiredFiles(versionName, manifest, uploads) {
   const populateUrl = `${apiBase}/${versionName}:populateFiles`;
-  const requiredHashes = new Set();
-  let uploadUrl;
+  let requiredCount = 0;
 
   for (const entries of chunk(Object.entries(manifest), populateBatchSize)) {
     const populate = await firebaseRequest(populateUrl, {
@@ -168,18 +216,20 @@ async function uploadRequiredFiles(versionName, manifest, uploads) {
       body: JSON.stringify({ files: Object.fromEntries(entries) }),
     });
 
-    uploadUrl = populate.uploadUrl;
-    for (const hash of populate.uploadRequiredHashes ?? []) {
-      requiredHashes.add(hash);
+    const requiredHashes = populate.uploadRequiredHashes ?? [];
+    requiredCount += requiredHashes.length;
+
+    if (!populate.uploadUrl && requiredHashes.length > 0) {
+      throw new Error('Firebase did not return an upload URL.');
     }
+
+    await uploadHashes(populate.uploadUrl, requiredHashes, uploads);
   }
 
-  console.log(`Firebase Hosting requires ${requiredHashes.size} file upload(s).`);
+  console.log(`Firebase Hosting requires ${requiredCount} file upload(s).`);
+}
 
-  if (!uploadUrl && requiredHashes.size > 0) {
-    throw new Error('Firebase did not return an upload URL.');
-  }
-
+async function uploadHashes(uploadUrl, requiredHashes, uploads) {
   const uploadOne = async (hash) => {
     const upload = uploads.get(hash);
     if (!upload) {
@@ -213,8 +263,8 @@ async function uploadRequiredFiles(versionName, manifest, uploads) {
 }
 
 async function main() {
-  const { publicDir, config } = await readHostingConfig();
-  const files = await walk(publicDir);
+  const { publicDir, ignore, config } = await readHostingConfig();
+  const files = filterIgnoredFiles(await walk(publicDir), ignore);
   if (files.length === 0) {
     throw new Error(`No files found in ${path.relative(process.cwd(), publicDir)}.`);
   }
@@ -223,6 +273,9 @@ async function main() {
 
   console.log(`Preparing Firebase Hosting deploy for site ${FIREBASE_HOSTING_SITE}.`);
   console.log(`Found ${files.length} file(s) in ${publicDirLabel}.`);
+  if (ignore.length > 0) {
+    console.log(`Applied ${ignore.length} firebase.json ignore pattern(s).`);
+  }
 
   const { manifest, uploads } = await buildManifest(files, publicDir);
   console.log(`Prepared ${Object.keys(manifest).length} Hosting manifest entrie(s).`);

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set derived deploy values
         run: |
@@ -58,7 +58,7 @@ jobs:
           : "${VITE_ADMIN_EMAILS:?Missing GitHub variable VITE_ADMIN_EMAILS}"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -79,22 +79,22 @@ jobs:
         run: npm run build
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: projects/81555493719/locations/global/workloadIdentityPools/github-pool/providers/github-provider
           service_account: github-deployer@nido-api-9ed65.iam.gserviceaccount.com
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push API container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -87,6 +87,24 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
+      - name: Resolve client API base URL
+        run: |
+          if [ -z "$VITE_API_BASE_URL" ]; then
+            API_URL="$(gcloud run services describe "$SERVICE" \
+              --project "$PROJECT_ID" \
+              --region "$REGION" \
+              --format 'value(status.url)')"
+            echo "VITE_API_BASE_URL=$API_URL" >> "$GITHUB_ENV"
+            echo "Client API URL: $API_URL"
+          else
+            echo "Client API URL: $VITE_API_BASE_URL"
+          fi
+
+      - name: Build client
+        run: |
+          npm run build --prefix client
+          echo "<!-- Build: $(date +%s) -->" >> client/dist/index.html
+
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 
@@ -119,16 +137,13 @@ jobs:
             --set-env-vars "$RUN_ENVS" \
             --set-secrets "$RUN_SECRETS"
 
-      - name: Resolve Cloud Run API URL
+      - name: Resolve deployed Cloud Run API URL
         run: |
           API_URL="$(gcloud run services describe "$SERVICE" \
             --project "$PROJECT_ID" \
             --region "$REGION" \
             --format 'value(status.url)')"
           echo "API_URL=$API_URL" >> "$GITHUB_ENV"
-          if [ -z "$VITE_API_BASE_URL" ]; then
-            echo "VITE_API_BASE_URL=$API_URL" >> "$GITHUB_ENV"
-          fi
           echo "Cloud Run API URL: $API_URL"
 
       - name: Verify API health
@@ -136,11 +151,6 @@ jobs:
           curl -fsS --retry 5 --retry-delay 5 "$API_URL/health"
           curl -fsS --retry 5 --retry-delay 5 "$API_URL/health/deep"
           curl -fsS --retry 5 --retry-delay 5 "$API_URL/api-docs-json" >/dev/null
-
-      - name: Build client
-        run: |
-          npm run build --prefix client
-          echo "<!-- Build: $(date +%s) -->" >> client/dist/index.html
 
       - name: Deploy Firebase Hosting
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,7 @@ jobs:
       REPO: nido
       SQL_INSTANCE: nido-postgres-dev
       FIREBASE_PROJECT_ID: nido-api-9ed65
+      FIREBASE_TOOLS_VERSION: 13.29.0
       RUNTIME_SERVICE_ACCOUNT: nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
       CORS_ORIGINS: ${{ vars.CORS_ORIGINS || 'https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com,http://localhost:5173' }}
       VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
@@ -132,8 +133,10 @@ jobs:
       - name: Deploy Firebase Hosting
         run: |
           echo "Starting Firebase Hosting deployment..."
-          DEPLOY_OUT=$(FIREBASE_TOKEN="$(gcloud auth print-access-token)" npx firebase-tools@latest deploy --only hosting --project "$FIREBASE_PROJECT_ID" 2>&1)
+          set +e
+          DEPLOY_OUT=$(npx --yes firebase-tools@"$FIREBASE_TOOLS_VERSION" deploy --only hosting --project "$FIREBASE_PROJECT_ID" --non-interactive 2>&1)
           STATUS=$?
+          set -e
           echo "$DEPLOY_OUT"
           if [ $STATUS -ne 0 ]; then
             if echo "$DEPLOY_OUT" | grep -q "is the current active version"; then

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: deploy-dev-main
+  group: deploy-dev-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       REPO: nido
       SQL_INSTANCE: nido-postgres-dev
       FIREBASE_PROJECT_ID: nido-api-9ed65
-      FIREBASE_TOOLS_VERSION: latest
+      FIREBASE_HOSTING_SITE: nido-api-9ed65
       RUNTIME_SERVICE_ACCOUNT: nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
       CORS_ORIGINS: ${{ vars.CORS_ORIGINS || 'https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com,http://localhost:5173' }}
       VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
@@ -46,6 +46,16 @@ jobs:
         run: |
           echo "SQL_CONNECTION=${PROJECT_ID}:${REGION}:${SQL_INSTANCE}" >> "$GITHUB_ENV"
           echo "IMAGE=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${SERVICE}:${GITHUB_SHA}" >> "$GITHUB_ENV"
+
+      - name: Validate deploy configuration
+        run: |
+          : "${VITE_FIREBASE_API_KEY:?Missing GitHub variable VITE_FIREBASE_API_KEY}"
+          : "${VITE_FIREBASE_AUTH_DOMAIN:?Missing GitHub variable VITE_FIREBASE_AUTH_DOMAIN}"
+          : "${VITE_FIREBASE_PROJECT_ID:?Missing GitHub variable VITE_FIREBASE_PROJECT_ID}"
+          : "${VITE_FIREBASE_STORAGE_BUCKET:?Missing GitHub variable VITE_FIREBASE_STORAGE_BUCKET}"
+          : "${VITE_FIREBASE_MESSAGING_SENDER_ID:?Missing GitHub variable VITE_FIREBASE_MESSAGING_SENDER_ID}"
+          : "${VITE_FIREBASE_APP_ID:?Missing GitHub variable VITE_FIREBASE_APP_ID}"
+          : "${VITE_ADMIN_EMAILS:?Missing GitHub variable VITE_ADMIN_EMAILS}"
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -90,6 +100,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy API to Cloud Run
         run: |
@@ -132,21 +144,8 @@ jobs:
 
       - name: Deploy Firebase Hosting
         run: |
-          echo "Starting Firebase Hosting deployment..."
-          set +e
-          DEPLOY_OUT=$(npx --yes firebase-tools@"$FIREBASE_TOOLS_VERSION" deploy --only hosting --project "$FIREBASE_PROJECT_ID" --non-interactive 2>&1)
-          STATUS=$?
-          set -e
-          echo "$DEPLOY_OUT"
-          if [ $STATUS -ne 0 ]; then
-            if echo "$DEPLOY_OUT" | grep -q "is the current active version"; then
-              echo "::warning::Firebase deploy reported 'active version' conflict, but files were successfully uploaded."
-              exit 0
-            else
-              echo "Firebase deploy failed with a real error."
-              exit $STATUS
-            fi
-          fi
+          FIREBASE_ACCESS_TOKEN="$(gcloud auth print-access-token)" \
+            node .github/scripts/deploy-firebase-hosting.mjs
 
       - name: Verify Firebase Hosting
         run: curl -fsSI "https://${FIREBASE_PROJECT_ID}.web.app" >/dev/null

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,7 +26,7 @@ jobs:
       REPO: nido
       SQL_INSTANCE: nido-postgres-dev
       FIREBASE_PROJECT_ID: nido-api-9ed65
-      FIREBASE_TOOLS_VERSION: 13.29.0
+      FIREBASE_TOOLS_VERSION: latest
       RUNTIME_SERVICE_ACCOUNT: nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
       CORS_ORIGINS: ${{ vars.CORS_ORIGINS || 'https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com,http://localhost:5173' }}
       VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}

--- a/.github/workflows/validate-deployment.yml
+++ b/.github/workflows/validate-deployment.yml
@@ -1,0 +1,83 @@
+name: Validate Deployment
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/deploy-dev.yml'
+      - '.github/workflows/validate-deployment.yml'
+      - '.github/scripts/deploy-firebase-hosting.mjs'
+      - '.github/DEPLOYMENT_SETUP.md'
+      - '.github/deploy-dev.env.example'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'firebase.json'
+      - 'nest-cli.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig*.json'
+      - 'src/**'
+      - 'client/**'
+  workflow_dispatch:
+
+concurrency:
+  group: validate-deployment-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate deploy build path
+    runs-on: ubuntu-latest
+
+    env:
+      FIREBASE_HOSTING_DRY_RUN: true
+      FIREBASE_PROJECT_ID: nido-api-9ed65
+      FIREBASE_HOSTING_SITE: nido-api-9ed65
+      VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ vars.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
+      VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'https://nido-api-81555493719.us-east1.run.app' }}
+      VITE_ADMIN_EMAILS: ${{ vars.VITE_ADMIN_EMAILS }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Validate deploy configuration
+        run: |
+          : "${VITE_FIREBASE_API_KEY:?Missing GitHub variable VITE_FIREBASE_API_KEY}"
+          : "${VITE_FIREBASE_AUTH_DOMAIN:?Missing GitHub variable VITE_FIREBASE_AUTH_DOMAIN}"
+          : "${VITE_FIREBASE_PROJECT_ID:?Missing GitHub variable VITE_FIREBASE_PROJECT_ID}"
+          : "${VITE_FIREBASE_STORAGE_BUCKET:?Missing GitHub variable VITE_FIREBASE_STORAGE_BUCKET}"
+          : "${VITE_FIREBASE_MESSAGING_SENDER_ID:?Missing GitHub variable VITE_FIREBASE_MESSAGING_SENDER_ID}"
+          : "${VITE_FIREBASE_APP_ID:?Missing GitHub variable VITE_FIREBASE_APP_ID}"
+          : "${VITE_ADMIN_EMAILS:?Missing GitHub variable VITE_ADMIN_EMAILS}"
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+
+      - name: Install API dependencies
+        run: npm ci
+
+      - name: Install client dependencies
+        run: npm ci --prefix client
+
+      - name: Run focused API tests
+        run: npm test -- user.service health.service concert-sync
+
+      - name: Build API
+        run: npm run build
+
+      - name: Build client
+        run: npm run build --prefix client
+
+      - name: Validate Firebase Hosting REST deploy
+        run: node .github/scripts/deploy-firebase-hosting.mjs


### PR DESCRIPTION
## Summary
- replace the Firebase CLI deploy path with a Firebase Hosting REST API deploy helper that works with WIF-issued access tokens
- reorder dev deployment so API and client builds pass before Cloud Run/Firebase changes are released
- add a non-deploy validation workflow for PRs touching deployment, API, or client build inputs
- update the deployment reference guide with the current workflow, validation posture, and troubleshooting notes

## Why
The previous Firebase CLI path failed in GitHub Actions because it could not authenticate from the WIF-generated environment. This branch keeps the deployment keyless, removes the deprecated token path, and improves release safety by validating build artifacts before mutating dev infrastructure.

## Validation
- YAML parsed for deploy and validation workflows
- node --check .github/scripts/deploy-firebase-hosting.mjs
- git diff --check
- npm test -- user.service health.service concert-sync
- npm run build
- npm run build --prefix client
- FIREBASE_HOSTING_DRY_RUN=true node .github/scripts/deploy-firebase-hosting.mjs

## Notes
The new Validate Deployment workflow is introduced in this PR. GitHub will recognize it once the PR/default-branch workflow context exists; local validation has already exercised the same commands.