### PR TITLE
[codex] Unify events feed around concerts

### DIFF
--- a/client/src/composables/useApi.ts
+++ b/client/src/composables/useApi.ts
@@ -42,7 +42,7 @@ export async function updateUserProfile(
   }
 }
 
-export async function fetchUserConcerts(
+export async function fetchConcerts(
   token: string,
   params?: {
     sort?: 'soonest' | 'featured' | 'trending_week';
@@ -52,6 +52,28 @@ export async function fetchUserConcerts(
 ): Promise<ConcertApiResponse> {
   try {
     const response = await apiClient.get<ConcertApiResponse>('/concerts', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching user concerts:', error);
+    throw error;
+  }
+}
+
+export async function fetchUserConcerts(
+  token: string,
+  params?: {
+    sort?: 'soonest' | 'featured' | 'trending_week';
+    startsAfter?: string;
+    pageSize?: number;
+  },
+): Promise<ConcertApiResponse> {
+  try {
+    const response = await apiClient.get<ConcertApiResponse>('/concerts/mine', {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -391,6 +413,7 @@ export interface AdminConcertUploadListItem {
   reviewedAt?: string;
   reviewedByUserId?: number;
   reviewedByUserEmail?: string;
+  concertId?: string;
 }
 
 export interface AdminConcertUploadListResponse {
@@ -419,7 +442,16 @@ export async function fetchAdminIngestionUploads(
 export async function reviewAdminIngestionUpload(
   token: string,
   uploadId: string,
-  payload: { status: UploadReviewStatus; notes?: string },
+  payload: {
+    status: UploadReviewStatus;
+    notes?: string;
+    concertTitle?: string;
+    concertGenre?: string;
+    concertStartsAt?: string;
+    concertVenueName?: string;
+    concertArtistName?: string;
+    concertDescription?: string;
+  },
 ) {
   const response = await apiClient.put<AdminConcertUploadListItem>(
     `/admin/ingestion/uploads/${uploadId}/review`,

--- a/client/src/pages/AdminIngestionUploadsPage.vue
+++ b/client/src/pages/AdminIngestionUploadsPage.vue
@@ -159,6 +159,38 @@
                 </select>
               </label>
             </details>
+            <div v-if="reviewStatusDraft === 'approved'" class="admin-uploads__publish-panel">
+              <div class="admin-uploads__publish-grid">
+                <label class="admin-uploads__control admin-uploads__control--stack">
+                  <span>Concert title</span>
+                  <input v-model="concertTitleDraft" type="text" placeholder="Doctor S at The Pour House" />
+                </label>
+                <label class="admin-uploads__control admin-uploads__control--stack">
+                  <span>Genre</span>
+                  <input v-model="concertGenreDraft" type="text" placeholder="Live Music" />
+                </label>
+                <label class="admin-uploads__control admin-uploads__control--stack">
+                  <span>Date</span>
+                  <input v-model="concertDateDraft" type="date" />
+                </label>
+                <label class="admin-uploads__control admin-uploads__control--stack">
+                  <span>Time</span>
+                  <input v-model="concertTimeDraft" type="time" />
+                </label>
+                <label class="admin-uploads__control admin-uploads__control--stack">
+                  <span>Venue</span>
+                  <input v-model="concertVenueNameDraft" type="text" placeholder="Venue TBD" />
+                </label>
+                <label class="admin-uploads__control admin-uploads__control--stack">
+                  <span>Artist / lineup</span>
+                  <input v-model="concertArtistNameDraft" type="text" placeholder="Artist or lineup" />
+                </label>
+              </div>
+              <label class="admin-uploads__control admin-uploads__control--stack">
+                <span>Public description</span>
+                <textarea v-model="concertDescriptionDraft" rows="3" placeholder="Short public note for the event card"></textarea>
+              </label>
+            </div>
             <label class="admin-uploads__control admin-uploads__control--stack">
               <span>Notes</span>
               <textarea v-model="reviewNotesDraft" rows="3" placeholder="Optional notes for the team"></textarea>
@@ -167,7 +199,7 @@
               <button
                 type="button"
                 class="admin-uploads__primary"
-                :disabled="!previewUpload || savingId === previewUpload.id"
+                :disabled="isSaveDisabled"
                 @click="saveReview"
               >
                 {{ savingId === previewUpload?.id ? 'Saving…' : 'Save review' }}
@@ -182,7 +214,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import {
   fetchAdminIngestionUploadImageBlob,
   fetchAdminIngestionUploads,
@@ -211,6 +243,13 @@ const previewLoading = ref(false);
 const previewError = ref('');
 const reviewStatusDraft = ref<UploadReviewStatus>('submitted');
 const reviewNotesDraft = ref('');
+const concertTitleDraft = ref('');
+const concertGenreDraft = ref('Live Music');
+const concertDateDraft = ref('');
+const concertTimeDraft = ref('19:00');
+const concertVenueNameDraft = ref('');
+const concertArtistNameDraft = ref('');
+const concertDescriptionDraft = ref('');
 
 const limit = 25;
 const offset = ref(0);
@@ -267,6 +306,13 @@ const formatLocation = (city?: string, state?: string) =>
 const formatStatus = (value: UploadReviewStatus) =>
   value.replace(/_/g, ' ');
 
+const defaultTitleFromFilename = (filename: string) =>
+  filename
+    .replace(/\.[^.]+$/, '')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
 const formatStorageUri = (value: string) => {
   if (value.length <= 72) {
     return value;
@@ -293,6 +339,13 @@ const openPreview = async (upload: AdminConcertUploadListItem) => {
 
   reviewStatusDraft.value = upload.reviewStatus;
   reviewNotesDraft.value = upload.reviewNotes ?? '';
+  concertTitleDraft.value = defaultTitleFromFilename(upload.originalFilename);
+  concertGenreDraft.value = 'Live Music';
+  concertDateDraft.value = '';
+  concertTimeDraft.value = '19:00';
+  concertVenueNameDraft.value = '';
+  concertArtistNameDraft.value = concertTitleDraft.value;
+  concertDescriptionDraft.value = '';
 
   try {
     const token = await getToken();
@@ -326,6 +379,22 @@ const setDraftStatus = (status: UploadReviewStatus) => {
   reviewStatusDraft.value = status;
 };
 
+const buildConcertStartsAt = () => {
+  if (!concertDateDraft.value || !concertTimeDraft.value) {
+    return undefined;
+  }
+
+  return new Date(`${concertDateDraft.value}T${concertTimeDraft.value}`).toISOString();
+};
+
+const isSaveDisabled = computed(
+  () =>
+    !previewUpload.value ||
+    savingId.value === previewUpload.value.id ||
+    (reviewStatusDraft.value === 'approved' &&
+      (!concertTitleDraft.value.trim() || !concertDateDraft.value || !concertTimeDraft.value)),
+);
+
 const saveReview = async () => {
   const upload = previewUpload.value;
   if (!upload) return;
@@ -336,6 +405,30 @@ const saveReview = async () => {
     const updated = await reviewAdminIngestionUpload(token, upload.id, {
       status: reviewStatusDraft.value,
       notes: reviewNotesDraft.value || undefined,
+      concertTitle:
+        reviewStatusDraft.value === 'approved'
+          ? concertTitleDraft.value.trim()
+          : undefined,
+      concertGenre:
+        reviewStatusDraft.value === 'approved'
+          ? concertGenreDraft.value.trim() || 'Live Music'
+          : undefined,
+      concertStartsAt:
+        reviewStatusDraft.value === 'approved'
+          ? buildConcertStartsAt()
+          : undefined,
+      concertVenueName:
+        reviewStatusDraft.value === 'approved'
+          ? concertVenueNameDraft.value.trim() || undefined
+          : undefined,
+      concertArtistName:
+        reviewStatusDraft.value === 'approved'
+          ? concertArtistNameDraft.value.trim() || concertTitleDraft.value.trim()
+          : undefined,
+      concertDescription:
+        reviewStatusDraft.value === 'approved'
+          ? concertDescriptionDraft.value.trim() || undefined
+          : undefined,
     });
     patchLocalUpload(updated);
   } catch (err: any) {
@@ -409,6 +502,7 @@ onBeforeUnmount(() => {
   color: var(--text-muted);
 }
 
+.admin-uploads__control input,
 .admin-uploads__control select,
 .admin-uploads__control textarea {
   border: 1px solid var(--border);
@@ -420,6 +514,20 @@ onBeforeUnmount(() => {
   min-width: 180px;
 }
 
+.admin-uploads__control input {
+  min-width: 0;
+}
+
+.admin-uploads__control textarea {
+  resize: vertical;
+}
+
+.admin-uploads__control input[type='date'],
+.admin-uploads__control input[type='time'] {
+  min-width: 0;
+}
+
+.admin-uploads__control--stack input,
 .admin-uploads__control--stack select,
 .admin-uploads__control--stack textarea {
   min-width: 0;
@@ -766,6 +874,21 @@ onBeforeUnmount(() => {
   color: var(--accent);
 }
 
+.admin-uploads__publish-panel {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.72rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface-soft);
+}
+
+.admin-uploads__publish-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
 .admin-uploads__review-actions {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -843,6 +966,10 @@ onBeforeUnmount(() => {
   }
 
   .admin-uploads__decision-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-uploads__publish-grid {
     grid-template-columns: 1fr;
   }
 

--- a/client/src/pages/EventsPage.vue
+++ b/client/src/pages/EventsPage.vue
@@ -158,7 +158,7 @@ import { useEventFilters } from '../composables/useEventFilters';
 import { sampleEvents } from '../data/sampleEvents';
 import {
   createConcert,
-  fetchUserConcerts,
+  fetchConcerts,
   removeConcertUpvote,
   upvoteConcert,
 } from '../composables/useApi';
@@ -303,7 +303,7 @@ const loadPersistedEvents = async () => {
 
   try {
     const token = await user.value.getIdToken();
-    const response = await fetchUserConcerts(token, {
+    const response = await fetchConcerts(token, {
       sort: sort.value,
       startsAfter: new Date().toISOString(),
       pageSize: 100,

--- a/src/apis/concerts/concert.controller.spec.ts
+++ b/src/apis/concerts/concert.controller.spec.ts
@@ -6,6 +6,7 @@ import { ListConcertsDto } from './dto/list-concerts.dto';
 
 describe('ConcertController', () => {
   const concertService = {
+    findAll: jest.fn(),
     findAllForOwner: jest.fn(),
     createForOwner: jest.fn(),
     upvote: jest.fn(),
@@ -25,16 +26,28 @@ describe('ConcertController', () => {
     );
   });
 
-  it('lists concerts for the synced user with query options', async () => {
+  it('lists concerts for the shared feed with query options', async () => {
     const decodedToken = { uid: 'uid-1' } as DecodedIdToken;
-    const owner = { id: 3 };
+    const currentUser = { id: 3 };
     const query = { sort: 'trending_week' } as ListConcertsDto;
-    userService.syncFromToken.mockResolvedValue(owner);
-    concertService.findAllForOwner.mockResolvedValue({ data: [] });
+    userService.syncFromToken.mockResolvedValue(currentUser);
+    concertService.findAll.mockResolvedValue({ data: [] });
 
     await controller.listConcerts(decodedToken, query);
 
     expect(userService.syncFromToken).toHaveBeenCalledWith(decodedToken);
+    expect(concertService.findAll).toHaveBeenCalledWith(query, currentUser);
+  });
+
+  it('lists concerts owned by the synced user with query options', async () => {
+    const decodedToken = { uid: 'uid-1' } as DecodedIdToken;
+    const owner = { id: 3 };
+    const query = { sort: 'soonest' } as ListConcertsDto;
+    userService.syncFromToken.mockResolvedValue(owner);
+    concertService.findAllForOwner.mockResolvedValue({ data: [] });
+
+    await controller.listMyConcerts(decodedToken, query);
+
     expect(concertService.findAllForOwner).toHaveBeenCalledWith(owner, query);
   });
 

--- a/src/apis/concerts/concert.controller.ts
+++ b/src/apis/concerts/concert.controller.ts
@@ -51,9 +51,9 @@ export class ConcertController {
 
   @Get()
   @ApiOperation({
-    summary: 'List concerts for the current user',
+    summary: 'List concerts for the shared discovery feed',
     description:
-      'Returns paginated concert records created manually, uploaded through ingestion, or produced by calendar sync.',
+      'Returns paginated upcoming concert records for the shared /events discovery feed. Results include concerts created manually, published from approved uploads, or produced by calendar sync across all users. Engagement state such as upvotedByMe is scoped to the signed-in user. Example: GET /concerts?sort=soonest&startsAfter=2026-07-03T19:04:08.267Z&pageSize=100.',
   })
   @ApiQuery({ name: 'q', required: false, example: 'doctor s' })
   @ApiQuery({ name: 'genre', required: false, example: 'Electronic' })
@@ -77,6 +77,41 @@ export class ConcertController {
   @ApiQuery({ name: 'pageSize', required: false, example: 20 })
   @ApiOkResponse({ type: ConcertListResponseDto })
   async listConcerts(
+    @CurrentUser() user: DecodedIdToken,
+    @Query() query: ListConcertsDto,
+  ) {
+    const currentUser = await this.ensureOwner(user);
+    return this.concertService.findAll(query, currentUser);
+  }
+
+  @Get('mine')
+  @ApiOperation({
+    summary: 'List concerts owned by the current user',
+    description:
+      'Returns paginated concert records created by, uploaded by, or synced for the signed-in user. This preserves the private My Concerts contract while GET /concerts serves the shared discovery feed. Example: GET /concerts/mine?sort=soonest&pageSize=20.',
+  })
+  @ApiQuery({ name: 'q', required: false, example: 'doctor s' })
+  @ApiQuery({ name: 'genre', required: false, example: 'Electronic' })
+  @ApiQuery({
+    name: 'startsAfter',
+    required: false,
+    example: '2026-06-01T00:00:00.000Z',
+  })
+  @ApiQuery({
+    name: 'startsBefore',
+    required: false,
+    example: '2026-07-01T00:00:00.000Z',
+  })
+  @ApiQuery({
+    name: 'sort',
+    required: false,
+    enum: ['soonest', 'featured', 'top_picks', 'trending_week'],
+    example: 'soonest',
+  })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'pageSize', required: false, example: 20 })
+  @ApiOkResponse({ type: ConcertListResponseDto })
+  async listMyConcerts(
     @CurrentUser() user: DecodedIdToken,
     @Query() query: ListConcertsDto,
   ) {

--- a/src/apis/concerts/concert.service.ts
+++ b/src/apis/concerts/concert.service.ts
@@ -33,17 +33,38 @@ export class ConcertService {
     private readonly concertUpvoteRepository: Repository<ConcertUpvote>,
   ) {}
 
+  async findAll(query: ListConcertsDto, currentUser?: User) {
+    const qb = this.concertRepository.createQueryBuilder('concert');
+    return this.findWithQuery(qb, query, currentUser);
+  }
+
   async findAllForOwner(owner: User, query: ListConcertsDto) {
-    const page = query.page ?? 1;
-    const pageSize = query.pageSize ?? 20;
     const qb = this.concertRepository
       .createQueryBuilder('concert')
       .where('concert.owner_id = :ownerId', { ownerId: owner.id });
+    return this.findWithQuery(qb, query, owner);
+  }
+
+  private async findWithQuery(
+    qb: ReturnType<Repository<Concert>['createQueryBuilder']>,
+    query: ListConcertsDto,
+    currentUser?: User,
+  ) {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 20;
 
     if (query.q) {
-      qb.andWhere('(concert.title ILIKE :q OR concert.description ILIKE :q)', {
-        q: `%${query.q}%`,
-      });
+      qb.andWhere(
+        `(
+          concert.title ILIKE :q
+          OR concert.description ILIKE :q
+          OR concert.venues::text ILIKE :q
+          OR concert.artists::text ILIKE :q
+        )`,
+        {
+          q: `%${query.q}%`,
+        },
+      );
     }
 
     if (query.genre) {
@@ -64,19 +85,20 @@ export class ConcertService {
 
     const total = await qb.clone().getCount();
     const trendingSince = this.getTrendingSince();
+    const currentUserId = currentUser?.id ?? null;
 
+    // Engagement and sync metadata are read-only decorations on the shared list.
     qb.leftJoin('concert_upvotes', 'upvote', 'upvote.concert_id = concert.id')
       .leftJoin(
         'concert_sync_events',
         'syncEvent',
-        'syncEvent.concert_id = concert.id AND syncEvent.owner_id = :ownerId',
-        { ownerId: owner.id },
+        'syncEvent.concert_id = concert.id',
       )
       .leftJoin(
         'concert_upvotes',
         'myUpvote',
         'myUpvote.concert_id = concert.id AND myUpvote.user_id = :currentUserId',
-        { currentUserId: owner.id },
+        { currentUserId },
       )
       .addSelect('COUNT(DISTINCT upvote.id)', 'upvote_count')
       .addSelect(

--- a/src/ingestion/admin-ingestion.controller.ts
+++ b/src/ingestion/admin-ingestion.controller.ts
@@ -74,14 +74,38 @@ export class AdminIngestionController {
   @ApiOperation({
     summary: 'Set review status for an uploaded concert asset',
     description:
-      'Admin-only endpoint for marking whether an uploaded flyer should remain submitted, be approved, rejected, or marked as a past event.',
+      'Admin-only endpoint for marking whether an uploaded flyer should remain submitted, be approved, rejected, or marked as a past event. When status is approved, concertTitle and concertStartsAt are required and the API publishes or updates a linked concert row in the shared /events feed. Example: PUT /admin/ingestion/uploads/87c28620-0a38-4187-89c8-c83a0246e828/review.',
   })
   @ApiParam({
     name: 'id',
     description: 'Concert upload id',
     example: '87c28620-0a38-4187-89c8-c83a0246e828',
   })
-  @ApiBody({ type: ReviewConcertUploadDto })
+  @ApiBody({
+    type: ReviewConcertUploadDto,
+    examples: {
+      approveAndPublish: {
+        summary: 'Approve upload and publish a concert',
+        value: {
+          status: 'approved',
+          notes: 'Flyer details confirmed.',
+          concertTitle: 'Doctor S at The Pour House',
+          concertGenre: 'Live Music',
+          concertStartsAt: '2026-07-10T23:00:00.000Z',
+          concertVenueName: 'The Pour House',
+          concertArtistName: 'Doctor S',
+          concertDescription: 'Approved flyer upload for the public feed.',
+        },
+      },
+      rejectUpload: {
+        summary: 'Reject upload without publishing',
+        value: {
+          status: 'rejected',
+          notes: 'Duplicate or not a concert flyer.',
+        },
+      },
+    },
+  })
   @ApiOkResponse({ type: AdminConcertUploadResponseDto })
   async reviewUpload(
     @Param('id') id: string,

--- a/src/ingestion/dto/ingestion-response.dto.ts
+++ b/src/ingestion/dto/ingestion-response.dto.ts
@@ -109,6 +109,9 @@ export class AdminConcertUploadResponseDto {
 
   @ApiPropertyOptional({ example: 'admin@example.local' })
   reviewedByUserEmail?: string;
+
+  @ApiPropertyOptional({ example: '87c28620-0a38-4187-89c8-c83a0246e828' })
+  concertId?: string;
 }
 
 export class AdminConcertUploadListResponseDto {

--- a/src/ingestion/dto/review-concert-upload.dto.ts
+++ b/src/ingestion/dto/review-concert-upload.dto.ts
@@ -1,4 +1,10 @@
-import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsIn,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { UploadReviewStatus } from '../entities/concert-upload.entity';
 
@@ -20,4 +26,62 @@ export class ReviewConcertUploadDto {
   @IsString()
   @MaxLength(2000)
   notes?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Concert title to publish when approving the upload. Required for approved uploads.',
+    example: 'Doctor S at The Pour House',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  concertTitle?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Genre label to publish when approving the upload. Defaults to Live Music.',
+    example: 'Live Music',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  concertGenre?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Start date/time to publish when approving the upload. Required for approved uploads.',
+    example: '2026-07-10T23:00:00.000Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  concertStartsAt?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Primary venue name to publish when approving the upload. Defaults to Venue TBD.',
+    example: 'The Pour House',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  concertVenueName?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Primary artist/lineup name to publish when approving the upload. Defaults to the concert title.',
+    example: 'Doctor S',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  concertArtistName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Public description to publish when approving the upload.',
+    example: 'Uploaded flyer approved by admin review.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  concertDescription?: string;
 }

--- a/src/ingestion/entities/concert-upload.entity.ts
+++ b/src/ingestion/entities/concert-upload.entity.ts
@@ -8,6 +8,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { User } from '../../apis/users/entities/user.entity';
+import { Concert } from '../../apis/concerts/entities/concert.entity';
 import { IngestionJob } from './ingestion-job.entity';
 
 export type UploadReviewStatus = 'submitted' | 'approved' | 'rejected' | 'past';
@@ -80,6 +81,17 @@ export class ConcertUpload {
   })
   @JoinColumn({ name: 'reviewed_by_user_id' })
   reviewedByUser?: User;
+
+  @Column({ name: 'concert_id', type: 'uuid', nullable: true })
+  concertId?: string | null;
+
+  @ManyToOne(() => Concert, {
+    eager: false,
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'concert_id' })
+  concert?: Concert | null;
 
   @OneToMany(() => IngestionJob, (ingestionJob) => ingestionJob.concertUpload)
   ingestionJobs: IngestionJob[];

--- a/src/ingestion/ingestion.module.ts
+++ b/src/ingestion/ingestion.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { UserModule } from '../apis/users/user.module';
+import { Concert } from '../apis/concerts/entities/concert.entity';
 import { IngestionJob } from './entities/ingestion-job.entity';
 import { ConcertUpload } from './entities/concert-upload.entity';
 import { AdminIngestionController } from './admin-ingestion.controller';
@@ -14,7 +15,7 @@ import { IngestionService } from './ingestion.service';
     ConfigModule,
     AuthModule,
     UserModule,
-    TypeOrmModule.forFeature([ConcertUpload, IngestionJob]),
+    TypeOrmModule.forFeature([Concert, ConcertUpload, IngestionJob]),
   ],
   controllers: [IngestionController, AdminIngestionController],
   providers: [IngestionService],

--- a/src/ingestion/ingestion.service.spec.ts
+++ b/src/ingestion/ingestion.service.spec.ts
@@ -10,6 +10,7 @@ import { IngestionService } from './ingestion.service';
 import { ConcertUpload } from './entities/concert-upload.entity';
 import { IngestionJob } from './entities/ingestion-job.entity';
 import { UploadableFile } from './interfaces/uploadable-file.interface';
+import { Concert } from '../apis/concerts/entities/concert.entity';
 
 describe('IngestionService', () => {
   let service: IngestionService;
@@ -19,6 +20,9 @@ describe('IngestionService', () => {
     save: jest.fn(),
     findOne: jest.fn(),
     findOneOrFail: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
 
   const ingestionJobRepository = {
@@ -27,9 +31,25 @@ describe('IngestionService', () => {
     findOne: jest.fn(),
     update: jest.fn(),
   };
+  const concertRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    concertUploadRepository.manager.transaction.mockImplementation(
+      async (callback) =>
+        callback({
+          getRepository: (entity: unknown) => {
+            if (entity === ConcertUpload) return concertUploadRepository;
+            if (entity === IngestionJob) return ingestionJobRepository;
+            if (entity === Concert) return concertRepository;
+            throw new Error('Unexpected repository token');
+          },
+        }),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -50,6 +70,10 @@ describe('IngestionService', () => {
         {
           provide: getRepositoryToken(IngestionJob),
           useValue: ingestionJobRepository,
+        },
+        {
+          provide: getRepositoryToken(Concert),
+          useValue: concertRepository,
         },
       ],
     }).compile();
@@ -218,9 +242,25 @@ describe('IngestionService', () => {
         reviewedByUser: { email: 'admin@example.local' },
       });
 
+      concertRepository.create.mockImplementation((value) => value);
+      concertRepository.save.mockResolvedValue({ id: 'concert-1' });
+
       const result = await service.adminReviewConcertUpload(
         'asset-1',
-        { status: reviewStatus, notes: 'reviewed' },
+        {
+          status: reviewStatus,
+          notes: 'reviewed',
+          concertTitle:
+            reviewStatus === 'approved' ? 'Poster Show' : undefined,
+          concertStartsAt:
+            reviewStatus === 'approved'
+              ? '2026-07-10T23:00:00.000Z'
+              : undefined,
+          concertVenueName:
+            reviewStatus === 'approved' ? 'The Venue' : undefined,
+          concertArtistName:
+            reviewStatus === 'approved' ? 'Poster Artist' : undefined,
+        },
         7,
       );
 
@@ -233,6 +273,16 @@ describe('IngestionService', () => {
       );
       expect(result.reviewStatus).toBe(reviewStatus);
       expect(result.reviewedByUserEmail).toBe('admin@example.local');
+      if (reviewStatus === 'approved') {
+        expect(concertRepository.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Poster Show',
+            startsAt: new Date('2026-07-10T23:00:00.000Z'),
+            isAdminApproved: true,
+            adminApprovedByUserId: 7,
+          }),
+        );
+      }
     },
   );
 
@@ -287,6 +337,10 @@ describe('IngestionService', () => {
         {
           provide: getRepositoryToken(IngestionJob),
           useValue: ingestionJobRepository,
+        },
+        {
+          provide: getRepositoryToken(Concert),
+          useValue: concertRepository,
         },
       ],
     }).compile();

--- a/src/ingestion/ingestion.service.ts
+++ b/src/ingestion/ingestion.service.ts
@@ -23,6 +23,7 @@ import type {
   AdminConcertUploadListResponse,
 } from './interfaces/admin-concert-upload.interface';
 import { UploadableFile } from './interfaces/uploadable-file.interface';
+import { Concert } from '../apis/concerts/entities/concert.entity';
 
 @Injectable()
 export class IngestionService {
@@ -37,6 +38,8 @@ export class IngestionService {
     private readonly concertUploadRepository: Repository<ConcertUpload>,
     @InjectRepository(IngestionJob)
     private readonly ingestionJobRepository: Repository<IngestionJob>,
+    @InjectRepository(Concert)
+    private readonly concertRepository: Repository<Concert>,
   ) {
     this.bucketName =
       this.configService.get<string>('GCS_INGESTION_BUCKET')?.trim() ||
@@ -351,27 +354,7 @@ export class IngestionService {
 
     const [uploads, total] = await qb.getManyAndCount();
 
-    const items: AdminConcertUploadListItem[] = uploads.map((upload) => ({
-      id: upload.id,
-      storageUri: upload.storageUri,
-      bucket: upload.bucket,
-      objectName: upload.objectName,
-      mimeType: upload.mimeType,
-      originalFilename: upload.originalFilename,
-      size: Number(upload.size),
-      city: upload.city,
-      state: upload.state,
-      source: upload.source,
-      uploadedByUid: upload.uploadedByUid,
-      uploadedByUserId: upload.uploadedByUserId,
-      uploadedByUserEmail: upload.uploadedByUser?.email,
-      createdAt: upload.createdAt.toISOString(),
-      reviewStatus: this.normalizeReviewStatus(upload.reviewStatus),
-      reviewNotes: upload.reviewNotes,
-      reviewedAt: upload.reviewedAt?.toISOString(),
-      reviewedByUserId: upload.reviewedByUserId,
-      reviewedByUserEmail: upload.reviewedByUser?.email,
-    }));
+    const items = uploads.map((upload) => this.mapAdminConcertUpload(upload));
 
     return { total, items };
   }
@@ -393,52 +376,138 @@ export class IngestionService {
       throw new NotFoundException(`Concert upload ${uploadId} not found`);
     }
 
-    upload.reviewStatus = dto.status;
-    upload.reviewNotes = dto.notes?.trim() || undefined;
-    upload.reviewedAt = new Date();
-    upload.reviewedByUserId = reviewedByUserId;
+    const hydrated = await this.concertUploadRepository.manager.transaction(
+      async (manager) => {
+        const uploadRepository = manager.getRepository(ConcertUpload);
+        const ingestionJobRepository = manager.getRepository(IngestionJob);
+        const concertRepository = manager.getRepository(Concert);
 
-    const saved = await this.concertUploadRepository.save(upload);
-    const terminalReviewStage = this.getTerminalReviewStage(dto.status);
-    if (terminalReviewStage) {
-      await this.ingestionJobRepository.update(
-        { concertUploadId: saved.id, status: 'needs_review' },
-        {
-          status: 'completed',
-          stage: terminalReviewStage,
-        },
+        upload.reviewStatus = dto.status;
+        upload.reviewNotes = dto.notes?.trim() || undefined;
+        upload.reviewedAt = new Date();
+        upload.reviewedByUserId = reviewedByUserId;
+
+        if (dto.status === 'approved') {
+          const concert = await this.publishApprovedUploadAsConcert(
+            upload,
+            dto,
+            reviewedByUserId,
+            concertRepository,
+          );
+          upload.concertId = concert.id;
+        }
+
+        const saved = await uploadRepository.save(upload);
+        const terminalReviewStage = this.getTerminalReviewStage(dto.status);
+        if (terminalReviewStage) {
+          await ingestionJobRepository.update(
+            { concertUploadId: saved.id, status: 'needs_review' },
+            {
+              status: 'completed',
+              stage: terminalReviewStage,
+            },
+          );
+        }
+
+        return uploadRepository.findOneOrFail({
+          where: { id: saved.id },
+          relations: {
+            uploadedByUser: true,
+            reviewedByUser: true,
+          },
+        });
+      },
+    );
+
+    return this.mapAdminConcertUpload(hydrated);
+  }
+
+  private mapAdminConcertUpload(
+    upload: ConcertUpload,
+  ): AdminConcertUploadListItem {
+    return {
+      id: upload.id,
+      storageUri: upload.storageUri,
+      bucket: upload.bucket,
+      objectName: upload.objectName,
+      mimeType: upload.mimeType,
+      originalFilename: upload.originalFilename,
+      size: Number(upload.size),
+      city: upload.city,
+      state: upload.state,
+      source: upload.source,
+      uploadedByUid: upload.uploadedByUid,
+      uploadedByUserId: upload.uploadedByUserId,
+      uploadedByUserEmail: upload.uploadedByUser?.email,
+      createdAt: upload.createdAt.toISOString(),
+      reviewStatus: this.normalizeReviewStatus(upload.reviewStatus),
+      reviewNotes: upload.reviewNotes ?? undefined,
+      reviewedAt: upload.reviewedAt?.toISOString(),
+      reviewedByUserId: upload.reviewedByUserId,
+      reviewedByUserEmail: upload.reviewedByUser?.email,
+      concertId: upload.concertId ?? undefined,
+    };
+  }
+
+  private async publishApprovedUploadAsConcert(
+    upload: ConcertUpload,
+    dto: ReviewConcertUploadDto,
+    reviewedByUserId: number,
+    concertRepository = this.concertRepository,
+  ) {
+    const title = dto.concertTitle?.trim();
+    const startsAt = dto.concertStartsAt?.trim();
+
+    if (!title || !startsAt) {
+      throw new BadRequestException(
+        'concertTitle and concertStartsAt are required when approving an upload.',
       );
     }
 
-    const hydrated = await this.concertUploadRepository.findOneOrFail({
-      where: { id: saved.id },
-      relations: {
-        uploadedByUser: true,
-        reviewedByUser: true,
-      },
-    });
+    const parsedStartsAt = new Date(startsAt);
+    if (Number.isNaN(parsedStartsAt.getTime())) {
+      throw new BadRequestException('concertStartsAt must be a valid date.');
+    }
 
-    return {
-      id: hydrated.id,
-      storageUri: hydrated.storageUri,
-      bucket: hydrated.bucket,
-      objectName: hydrated.objectName,
-      mimeType: hydrated.mimeType,
-      originalFilename: hydrated.originalFilename,
-      size: Number(hydrated.size),
-      city: hydrated.city,
-      state: hydrated.state,
-      source: hydrated.source,
-      uploadedByUid: hydrated.uploadedByUid,
-      uploadedByUserId: hydrated.uploadedByUserId,
-      uploadedByUserEmail: hydrated.uploadedByUser?.email,
-      createdAt: hydrated.createdAt.toISOString(),
-      reviewStatus: this.normalizeReviewStatus(hydrated.reviewStatus),
-      reviewNotes: hydrated.reviewNotes ?? undefined,
-      reviewedAt: hydrated.reviewedAt?.toISOString(),
-      reviewedByUserId: hydrated.reviewedByUserId,
-      reviewedByUserEmail: hydrated.reviewedByUser?.email,
-    };
+    const ownerId = upload.uploadedByUserId ?? reviewedByUserId;
+    const existingConcert = upload.concertId
+      ? await concertRepository.findOne({ where: { id: upload.concertId } })
+      : null;
+    const concert =
+      existingConcert ??
+      concertRepository.create({
+        owner: { id: ownerId },
+      });
+    const genre = dto.concertGenre?.trim() || 'Live Music';
+
+    concert.owner = { id: ownerId } as Concert['owner'];
+    concert.title = title;
+    concert.genre = genre;
+    concert.startsAt = parsedStartsAt;
+    concert.endsAt = null;
+    concert.venues = [
+      {
+        name: dto.concertVenueName?.trim() || 'Venue TBD',
+        city: upload.city,
+        state: upload.state,
+      },
+    ];
+    concert.artists = [
+      {
+        name: dto.concertArtistName?.trim() || title,
+        role: 'headliner',
+        genre,
+      },
+    ];
+    concert.description =
+      dto.concertDescription?.trim() ||
+      dto.notes?.trim() ||
+      `Approved flyer upload: ${upload.originalFilename}`;
+    concert.isAdminApproved = true;
+    concert.adminApprovedAt = new Date();
+    concert.adminApprovedByUserId = reviewedByUserId;
+
+    return concertRepository.save(concert);
   }
 
   async adminStreamUploadImage(uploadId: string, res: Response): Promise<void> {

--- a/src/ingestion/interfaces/admin-concert-upload.interface.ts
+++ b/src/ingestion/interfaces/admin-concert-upload.interface.ts
@@ -20,10 +20,10 @@ export interface AdminConcertUploadListItem {
   reviewedAt?: string;
   reviewedByUserId?: number;
   reviewedByUserEmail?: string;
+  concertId?: string;
 }
 
 export interface AdminConcertUploadListResponse {
   total: number;
   items: AdminConcertUploadListItem[];
 }
-

--- a/src/migrations/1760000006000-LinkConcertUploadsToConcerts.ts
+++ b/src/migrations/1760000006000-LinkConcertUploadsToConcerts.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LinkConcertUploadsToConcerts1760000006000
+  implements MigrationInterface
+{
+  name = 'LinkConcertUploadsToConcerts1760000006000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "concert_uploads"
+      ADD COLUMN IF NOT EXISTS "concert_id" uuid
+    `);
+
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_concert_uploads_concert_id_concerts_id'
+        ) THEN
+          ALTER TABLE "concert_uploads"
+          ADD CONSTRAINT "FK_concert_uploads_concert_id_concerts_id"
+          FOREIGN KEY ("concert_id") REFERENCES "concerts"("id") ON DELETE SET NULL;
+        END IF;
+      END $$;
+    `);
+
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_concert_uploads_concert_id" ON "concert_uploads" ("concert_id")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_concert_uploads_concert_id"',
+    );
+    await queryRunner.query(`
+      ALTER TABLE "concert_uploads"
+      DROP CONSTRAINT IF EXISTS "FK_concert_uploads_concert_id_concerts_id"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "concert_uploads"
+      DROP COLUMN IF EXISTS "concert_id"
+    `);
+  }
+}


### PR DESCRIPTION
## Developer Prompt

Issue #30 reframes `/events` as a unified Concerts discovery view.

As a standard signed-in user, I should see all upcoming concert rows at:

```text
https://nido-api-9ed65.web.app/events
```

The frontend route remains `/events`, but the product concept is now a shared Concerts feed. Rows are backed by the `concerts` table/entity. Concerts created by the Doctor S sync job should appear here. Flyer uploads should appear here only after an admin approves and publishes them with enough structured concert data. Future work can add `My Concerts` and `My Uploaded Concerts` filters, but this PR keeps the immediate scope focused on a shared upcoming concerts feed.

## Steps Required To Transform The View

1. Validate the bug against live dev data:
   - `concert_uploads` had approved rows.
   - `ingestion_jobs` had completed `admin_approved` rows.
   - `concerts` had no upcoming rows, so `/concerts?startsAfter=...` correctly returned an empty list.

2. Confirm sync behavior:
   - Doctor S sync jobs already create/update rows in `concerts`.
   - The missing behavior was visibility: `GET /concerts` was scoped to the signed-in owner, so a standard user could not see synced concerts owned by another account.

3. Split API responsibilities:
   - `GET /concerts` now serves the shared discovery feed.
   - `GET /concerts/mine` preserves the old user-owned list behavior for future My Concerts workflows.

4. Update the frontend data contract:
   - `/events` now calls the shared concerts feed.
   - Existing My Concerts UI continues to call the user-owned endpoint.

5. Add upload-to-concert publishing:
   - Admin approval now requires minimum publish fields: title and start date/time.
   - Admins can provide genre, venue, artist, and public description.
   - Approved uploads create/update a linked `concerts` row.

6. Add persistence support:
   - Add nullable `concert_uploads.concert_id`.
   - Add a foreign key to `concerts.id`.
   - Return `concertId` in admin upload responses.

7. Harden consistency:
   - Review status update, concert publish, upload link, and ingestion job completion now run in one transaction.
   - This avoids an approved upload being saved without its linked concert if publish validation fails.

8. Polish API documentation:
   - Swagger descriptions now explain shared vs. owned list behavior.
   - Swagger examples document `GET /concerts`, `GET /concerts/mine`, and upload approval request bodies.

## Summary Of Changes

- Reworked `GET /concerts` as the shared Concerts discovery feed for `/events`.
- Added `GET /concerts/mine` for user-owned concerts.
- Updated `/events` frontend data loading to use the shared feed.
- Kept My Concerts on the owned feed.
- Added admin publish fields to upload review.
- Added transactional publish-on-approval for uploaded flyers.
- Added `concert_uploads.concert_id` migration and response field.
- Improved search behavior so `q` searches title, description, venues, and artists.
- Updated tests for shared vs. owned API behavior and upload publishing.
- Expanded Swagger documentation and request examples.

## Senior Review Notes

The first implementation worked functionally, but it had a consistency risk: upload approval was saved before concert publishing. That could leave `review_status=approved` without a public concert if the publish payload failed validation. This PR now wraps the approval path in a transaction.

The API split is intentionally conservative:

- Shared discovery: `GET /concerts`
- User-owned list: `GET /concerts/mine`

This avoids adding flags like `scope=all|mine` before the product has more filter modes, while preserving a clean future path for `My Concerts`, `My Uploaded Concerts`, liked concerts, saved concerts, and admin moderation views.

Remaining design improvements worth considering later:

- Add first-class source fields on `concerts`, such as `sourceType`, `sourceUploadId`, and `sourceSyncEventId`, instead of relying only on joins.
- Add a dedicated public/admin publish DTO if upload review grows further.
- Add an admin backfill tool for already-approved uploads that predate the new publish fields.
- Decide whether all manually created concerts should be visible in the shared feed immediately or require admin approval.
- Add end-to-end API tests around `GET /concerts` visibility once test DB fixtures exist.

## Root Cause

Admin approval previously updated `concert_uploads.review_status` and ingestion job stage, but did not create a row in `concerts`. Separately, synced concerts were already written to `concerts`, but the existing `GET /concerts` endpoint filtered by owner. That meant standard users could see `0 shows` even when synced or approved data existed elsewhere.

## Validation

- `npm test -- concert.controller ingestion.service concert.service`
- `npm test -- user.service health.service concert-sync`
- `npm run build`
- `npm run build --prefix client`
- `git diff --check`

Closes #30
