### PR TITLE
Fix approved upload publishing flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,9 +38,9 @@ ADMIN_EMAILS=ezvibesinc@gmail.com
 
 # Gemini extraction
 GEMINI_API_KEY=
-# Optional. Defaults to gemini-2.0-flash in code.
-GEMINI_MODEL=gemini-2.0-flash
-CONCERT_SYNC_GEMINI_ENABLED=true
+# Optional. Defaults to gemini-2.5-flash in code.
+GEMINI_MODEL=gemini-2.5-flash
+CONCERT_SYNC_GEMINI_ENABLED=false
 
 # Concert sync extraction policy
 CONCERT_SYNC_ALLOWED_GENRES=Hip Hop,Latin,Metal,Electronic,Jazz,Country,R&B,Indie,Rock,Pop,Live

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -112,6 +112,28 @@ Runtime service account: nido-api-runtime@nido-api-9ed65.iam.gserviceaccount.com
 Deploy service account: github-deployer@nido-api-9ed65.iam.gserviceaccount.com
 ```
 
+Current dev runtime posture:
+
+```text
+DB_SYNCHRONIZE=false
+DB_MIGRATIONS_RUN=true
+GEMINI_MODEL=gemini-2.5-flash
+CONCERT_SYNC_GEMINI_ENABLED=false
+CONCERT_SYNC_MAX_EVENTS_PER_JOB=25
+```
+
+Gemini extraction is intentionally disabled in the main dev deployment for now.
+Sync Doctor and ingestion approval should use deterministic fallback behavior unless
+`CONCERT_SYNC_GEMINI_ENABLED` is explicitly enabled for a targeted test. Keep the
+`nido-gemini-api-key` secret available so Gemini can be tested without changing the
+Secret Manager shape, but do not enable paid Gemini calls as the default dev deploy
+behavior.
+
+Admin ingestion approval currently publishes approved, future-dated flyer uploads
+into the shared `/events` discovery feed. The frontend events page requests
+`/concerts` with `startsAfter=<current time>`, so approved uploads whose event date
+is in the past will not appear in the public events list.
+
 ## Pipeline Sequence
 
 The `Deploy Dev` workflow runs on:
@@ -322,11 +344,34 @@ DB_SYNCHRONIZE=false
 DB_MIGRATIONS_RUN=true
 ```
 
+Current API runtime env set by `.github/workflows/deploy-dev.yml`:
+
+```text
+NODE_ENV=production
+DB_HOST=/cloudsql/nido-api-9ed65:us-east1:nido-postgres-dev
+DB_PORT=5432
+DB_USER=nido_api
+DB_NAME=nido
+DB_SYNCHRONIZE=false
+DB_MIGRATIONS_RUN=true
+FIREBASE_PROJECT_ID=nido-api-9ed65
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-fbsvc@nido-api-9ed65.iam.gserviceaccount.com
+ADMIN_EMAILS=ezvibesinc@gmail.com
+GCS_INGESTION_BUCKET=nido-concert-image-ingestion-dev
+GEMINI_MODEL=gemini-2.5-flash
+CONCERT_SYNC_GEMINI_ENABLED=false
+CONCERT_SYNC_MAX_EVENTS_PER_JOB=25
+GOOGLE_CALENDAR_SERVICE_ACCOUNT_EMAIL=sync-doctor-calendar@nido-api.iam.gserviceaccount.com
+CORS_ORIGINS=https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.com,http://localhost:5173
+```
+
 Production hardening:
 
 - Keep `DB_SYNCHRONIZE=false`.
 - Prefer explicit migrations.
 - Verify migrations are idempotent and logged.
+- Keep Gemini disabled by default until extraction quality, cost, and quota behavior
+  are ready for normal deploys.
 
 ## Firebase Hosting REST Deployment
 
@@ -478,6 +523,8 @@ nido-google-calendar-private-key
 
 Do not store these in GitHub Actions secrets unless there is a clear, reviewed reason.
 The deployed Cloud Run service reads them at runtime through Secret Manager bindings.
+The Gemini secret can stay configured while `CONCERT_SYNC_GEMINI_ENABLED=false`; the
+service will use fallback extraction and report `fallbackReason=gemini_disabled`.
 
 ## First-Time Setup Checklist
 
@@ -537,6 +584,19 @@ curl -fsS https://nido-api-81555493719.us-east1.run.app/health/deep
 curl -fsS https://nido-api-81555493719.us-east1.run.app/api-docs-json >/dev/null
 curl -fsSI https://nido-api-9ed65.web.app >/dev/null
 ```
+
+Admin approval smoke test:
+
+1. Sign in to `https://nido-api-9ed65.web.app` as an email listed in both
+   `ADMIN_EMAILS` and `VITE_ADMIN_EMAILS`.
+2. Upload a flyer through the public Events intake.
+3. Open `/admin/ingestion/uploads`.
+4. Select the uploaded flyer, choose `Approve`, and fill a future date/time.
+5. Click `Approve and publish`.
+6. Confirm the modal closes and the row reloads with approved status.
+7. Open `/events` and confirm the approved future show appears in the public list.
+8. If the show does not appear, verify the event date is future-dated because the
+   Events page filters with `startsAfter=<current time>`.
 
 ## Troubleshooting
 

--- a/.github/deploy-dev.env.example
+++ b/.github/deploy-dev.env.example
@@ -11,6 +11,13 @@ CORS_ORIGINS=https://nido-api-9ed65.web.app,https://nido-api-9ed65.firebaseapp.c
 # Frontend admin allowlist.
 VITE_ADMIN_EMAILS=ezvibesinc@gmail.com
 
+# Backend runtime env is set in deploy-dev.yml and should match live dev:
+# - GEMINI_MODEL=gemini-2.5-flash
+# - CONCERT_SYNC_GEMINI_ENABLED=false
+# - DB_SYNCHRONIZE=false
+# - DB_MIGRATIONS_RUN=true
+# Runtime secrets stay in Secret Manager, not GitHub variables.
+
 # Firebase Web App config. These are public browser config values, not Firebase Admin credentials.
 VITE_FIREBASE_API_KEY=<firebase-web-api-key>
 VITE_FIREBASE_AUTH_DOMAIN=nido-api-9ed65.firebaseapp.com

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Deploy API to Cloud Run
         run: |
-          RUN_ENVS="^|^NODE_ENV=production|DB_HOST=/cloudsql/${SQL_CONNECTION}|DB_PORT=5432|DB_USER=nido_api|DB_NAME=nido|DB_SYNCHRONIZE=false|DB_MIGRATIONS_RUN=true|FIREBASE_PROJECT_ID=${PROJECT_ID}|FIREBASE_CLIENT_EMAIL=firebase-adminsdk-fbsvc@${PROJECT_ID}.iam.gserviceaccount.com|ADMIN_EMAILS=ezvibesinc@gmail.com|GCS_INGESTION_BUCKET=nido-concert-image-ingestion-dev|GEMINI_MODEL=gemini-2.0-flash|CONCERT_SYNC_GEMINI_ENABLED=true|CONCERT_SYNC_MAX_EVENTS_PER_JOB=25|GOOGLE_CALENDAR_SERVICE_ACCOUNT_EMAIL=sync-doctor-calendar@nido-api.iam.gserviceaccount.com|CORS_ORIGINS=${CORS_ORIGINS}"
+          RUN_ENVS="^|^NODE_ENV=production|DB_HOST=/cloudsql/${SQL_CONNECTION}|DB_PORT=5432|DB_USER=nido_api|DB_NAME=nido|DB_SYNCHRONIZE=false|DB_MIGRATIONS_RUN=true|FIREBASE_PROJECT_ID=${PROJECT_ID}|FIREBASE_CLIENT_EMAIL=firebase-adminsdk-fbsvc@${PROJECT_ID}.iam.gserviceaccount.com|ADMIN_EMAILS=ezvibesinc@gmail.com|GCS_INGESTION_BUCKET=nido-concert-image-ingestion-dev|GEMINI_MODEL=gemini-2.5-flash|CONCERT_SYNC_GEMINI_ENABLED=false|CONCERT_SYNC_MAX_EVENTS_PER_JOB=25|GOOGLE_CALENDAR_SERVICE_ACCOUNT_EMAIL=sync-doctor-calendar@nido-api.iam.gserviceaccount.com|CORS_ORIGINS=${CORS_ORIGINS}"
           RUN_SECRETS="DB_PASSWORD=nido-db-password:latest,FIREBASE_PRIVATE_KEY=nido-firebase-private-key:latest,GEMINI_API_KEY=nido-gemini-api-key:latest,GOOGLE_CALENDAR_SERVICE_ACCOUNT_PRIVATE_KEY=nido-google-calendar-private-key:latest"
 
           gcloud run deploy "$SERVICE" \

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Required env:
 
 ### Admin Review
 
-Admin-only endpoints are under `/admin/ingestion/*` (list uploads, preview images, and set review status/notes).
+Admin-only endpoints are under `/admin/ingestion/*` (list uploads, preview images, and set review status/notes). When an upload is approved with concert title and start time, the API publishes or updates a linked concert in the shared `/events` feed. The public Events page only lists future concerts.
 
 - Backend allowlist: set `ADMIN_EMAILS` (comma-separated emails) in `.env`
 - Client menu allowlist: set `VITE_ADMIN_EMAILS` (comma-separated emails) in `client/.env`
@@ -138,8 +138,8 @@ The API now includes a sync agent under `/concert-sync/*` that can:
 Required env for AI enrichment:
 
 - `GEMINI_API_KEY`
-- Optional `GEMINI_MODEL` (defaults to `gemini-2.0-flash`)
-- Optional `CONCERT_SYNC_GEMINI_ENABLED=false` disables paid Gemini calls and uses deterministic fallback extraction.
+- Optional `GEMINI_MODEL` (defaults to `gemini-2.5-flash`)
+- Optional `CONCERT_SYNC_GEMINI_ENABLED=true` enables paid Gemini calls. Keep it `false` to use deterministic fallback extraction.
 - Optional extraction policy controls:
   - `CONCERT_SYNC_ALLOWED_GENRES`
   - `CONCERT_SYNC_MIN_CONFIDENCE`

--- a/client/src/pages/AdminIngestionUploadsPage.vue
+++ b/client/src/pages/AdminIngestionUploadsPage.vue
@@ -195,6 +195,17 @@
               <span>Notes</span>
               <textarea v-model="reviewNotesDraft" rows="3" placeholder="Optional notes for the team"></textarea>
             </label>
+            <p
+              v-if="reviewMessage"
+              :class="[
+                'admin-uploads__review-message',
+                reviewMessageType === 'success'
+                  ? 'admin-uploads__review-message--success'
+                  : 'admin-uploads__review-message--error',
+              ]"
+            >
+              {{ reviewMessage }}
+            </p>
             <div class="admin-uploads__review-actions">
               <button
                 type="button"
@@ -202,7 +213,7 @@
                 :disabled="isSaveDisabled"
                 @click="saveReview"
               >
-                {{ savingId === previewUpload?.id ? 'Saving…' : 'Save review' }}
+                {{ saveButtonLabel }}
               </button>
               <button type="button" class="admin-uploads__secondary" @click="closePreview">Done</button>
             </div>
@@ -243,6 +254,8 @@ const previewLoading = ref(false);
 const previewError = ref('');
 const reviewStatusDraft = ref<UploadReviewStatus>('submitted');
 const reviewNotesDraft = ref('');
+const reviewMessage = ref('');
+const reviewMessageType = ref<'success' | 'error'>('success');
 const concertTitleDraft = ref('');
 const concertGenreDraft = ref('Live Music');
 const concertDateDraft = ref('');
@@ -334,6 +347,7 @@ const openPreview = async (upload: AdminConcertUploadListItem) => {
   previewOpen.value = true;
   previewUpload.value = upload;
   previewError.value = '';
+  reviewMessage.value = '';
   previewLoading.value = true;
   revokePreviewUrl();
 
@@ -362,6 +376,7 @@ const closePreview = () => {
   previewOpen.value = false;
   previewUpload.value = null;
   previewError.value = '';
+  reviewMessage.value = '';
   previewLoading.value = false;
   revokePreviewUrl();
 };
@@ -377,6 +392,7 @@ const patchLocalUpload = (updated: AdminConcertUploadListItem) => {
 
 const setDraftStatus = (status: UploadReviewStatus) => {
   reviewStatusDraft.value = status;
+  reviewMessage.value = '';
 };
 
 const buildConcertStartsAt = () => {
@@ -395,11 +411,33 @@ const isSaveDisabled = computed(
       (!concertTitleDraft.value.trim() || !concertDateDraft.value || !concertTimeDraft.value)),
 );
 
+const saveButtonLabel = computed(() => {
+  if (savingId.value === previewUpload.value?.id) {
+    return 'Saving...';
+  }
+
+  if (reviewStatusDraft.value === 'approved') {
+    return 'Approve and publish';
+  }
+
+  if (reviewStatusDraft.value === 'rejected') {
+    return 'Save rejection';
+  }
+
+  if (reviewStatusDraft.value === 'past') {
+    return 'Mark past';
+  }
+
+  return 'Save review';
+});
+
 const saveReview = async () => {
   const upload = previewUpload.value;
   if (!upload) return;
 
   savingId.value = upload.id;
+  previewError.value = '';
+  reviewMessage.value = '';
   try {
     const token = await getToken();
     const updated = await reviewAdminIngestionUpload(token, upload.id, {
@@ -431,8 +469,19 @@ const saveReview = async () => {
           : undefined,
     });
     patchLocalUpload(updated);
+    void load();
+    reviewMessageType.value = 'success';
+    reviewMessage.value =
+      updated.reviewStatus === 'approved'
+        ? 'Approved and published to the events feed.'
+        : 'Review saved.';
+    if (updated.reviewStatus === 'approved') {
+      window.dispatchEvent(new CustomEvent('concerts:changed'));
+      closePreview();
+    }
   } catch (err: any) {
-    previewError.value = err?.message ?? 'Failed to save review.';
+    reviewMessageType.value = 'error';
+    reviewMessage.value = err?.message ?? 'Failed to save review.';
   } finally {
     savingId.value = '';
   }
@@ -688,7 +737,7 @@ onBeforeUnmount(() => {
   z-index: 60;
   display: grid;
   place-items: center;
-  padding: 1rem;
+  padding: clamp(0.5rem, 2vw, 1rem);
 }
 
 .admin-uploads__modal-backdrop {
@@ -700,7 +749,7 @@ onBeforeUnmount(() => {
 .admin-uploads__modal-card {
   position: relative;
   width: min(1200px, 96vw);
-  max-height: min(820px, 90vh);
+  max-height: calc(100dvh - 2rem);
   background: var(--surface);
   border-radius: 18px;
   border: 1px solid var(--border);
@@ -743,11 +792,12 @@ onBeforeUnmount(() => {
 
 .admin-uploads__modal-body {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.85fr);
+  grid-template-columns: minmax(0, 1.35fr) minmax(380px, 0.95fr);
   gap: 0.85rem;
   padding: 0.85rem 0.95rem 0.95rem;
-  overflow: hidden;
+  overflow: auto;
   align-items: stretch;
+  min-height: 0;
 }
 
 .admin-uploads__preview {
@@ -758,12 +808,15 @@ onBeforeUnmount(() => {
   place-items: center;
   padding: 0.7rem;
   min-height: 0;
-  height: 100%;
+  height: fit-content;
+  max-height: 100%;
+  position: sticky;
+  top: 0;
 }
 
 .admin-uploads__preview-image {
   max-width: 100%;
-  max-height: min(62vh, 640px);
+  max-height: min(64dvh, 640px);
   border-radius: 12px;
   box-shadow: var(--shadow);
 }
@@ -781,7 +834,7 @@ onBeforeUnmount(() => {
 .admin-uploads__review {
   display: grid;
   gap: 0.6rem;
-  grid-template-rows: auto auto auto 1fr auto;
+  align-content: start;
   min-height: 0;
 }
 
@@ -876,8 +929,8 @@ onBeforeUnmount(() => {
 
 .admin-uploads__publish-panel {
   display: grid;
-  gap: 0.55rem;
-  padding: 0.72rem 0.8rem;
+  gap: 0.75rem;
+  padding: 0.85rem;
   border: 1px solid var(--border);
   border-radius: 16px;
   background: var(--surface-soft);
@@ -885,8 +938,41 @@ onBeforeUnmount(() => {
 
 .admin-uploads__publish-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+.admin-uploads__publish-panel .admin-uploads__control {
+  gap: 0.35rem;
+}
+
+.admin-uploads__publish-panel .admin-uploads__control input,
+.admin-uploads__publish-panel .admin-uploads__control textarea {
+  min-height: 3rem;
+}
+
+.admin-uploads__publish-panel .admin-uploads__control textarea {
+  min-height: 7rem;
+}
+
+.admin-uploads__review-message {
+  margin: 0;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.admin-uploads__review-message--success {
+  border: 1px solid rgba(43, 130, 79, 0.28);
+  color: #21663f;
+  background: rgba(43, 130, 79, 0.1);
+}
+
+.admin-uploads__review-message--error {
+  border: 1px solid rgba(186, 64, 41, 0.28);
+  color: var(--accent);
+  background: rgba(186, 64, 41, 0.1);
 }
 
 .admin-uploads__review-actions {
@@ -894,6 +980,16 @@ onBeforeUnmount(() => {
   grid-template-columns: 1fr auto;
   gap: 0.45rem;
   align-self: end;
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  margin: 0 -0.1rem -0.1rem;
+  padding: 0.55rem 0.1rem 0.1rem;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0),
+    var(--surface) 32%
+  );
 }
 
 .admin-uploads__advanced {
@@ -959,6 +1055,15 @@ onBeforeUnmount(() => {
   .admin-uploads__modal-body {
     grid-template-columns: 1fr;
     overflow: auto;
+  }
+
+  .admin-uploads__preview {
+    position: static;
+    max-height: none;
+  }
+
+  .admin-uploads__preview-image {
+    max-height: min(42dvh, 420px);
   }
 
   .admin-uploads__details {

--- a/client/src/pages/EventsPage.vue
+++ b/client/src/pages/EventsPage.vue
@@ -150,7 +150,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import EventCard from '../components/events/EventCard.vue';
 import EventFiltersBar from '../components/events/EventFiltersBar.vue';
 import IngestionUploadPanel from '../components/ingestion/IngestionUploadPanel.vue';
@@ -327,6 +327,10 @@ const loadPersistedEvents = async () => {
   }
 };
 
+const handleConcertsChanged = () => {
+  void loadPersistedEvents();
+};
+
 const handleToggleUpvote = async (event: EventListItem) => {
   if (
     !user.value ||
@@ -445,6 +449,14 @@ watch(sort, (nextSort) => {
   if (nextSort === 'trending_week' && hasLoadedPersistedEvents.value) {
     void loadPersistedEvents();
   }
+});
+
+onMounted(() => {
+  window.addEventListener('concerts:changed', handleConcertsChanged);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('concerts:changed', handleConcertsChanged);
 });
 </script>
 

--- a/src/concert-sync/services/gemini-concert-extractor.service.spec.ts
+++ b/src/concert-sync/services/gemini-concert-extractor.service.spec.ts
@@ -38,4 +38,30 @@ describe('GeminiConcertExtractorService', () => {
       },
     ]);
   });
+
+  it('uses heuristic extraction with the current default model when Gemini is disabled', async () => {
+    configService.get.mockImplementation((key: string) =>
+      key === 'CONCERT_SYNC_GEMINI_ENABLED' ? 'false' : undefined,
+    );
+
+    const extraction = await service.extractConcert(
+      {
+        id: 'event-2',
+        status: 'confirmed',
+        summary: 'Doctor S Presents: Neon Tide with DJ Luna',
+        location: 'The Evening Muse, Charlotte, NC',
+        start: {
+          dateTime: '2026-07-10T20:00:00-04:00',
+          timeZone: 'America/New_York',
+        },
+      },
+      {},
+    );
+
+    expect(extraction).toMatchObject({
+      extractionSource: 'heuristic',
+      fallbackReason: 'gemini_disabled',
+      model: 'gemini-2.5-flash',
+    });
+  });
 });

--- a/src/concert-sync/services/gemini-concert-extractor.service.ts
+++ b/src/concert-sync/services/gemini-concert-extractor.service.ts
@@ -10,6 +10,8 @@ interface ExtractionContext {
   customContext?: string;
 }
 
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
+
 export interface ConcertExtractionPolicy {
   allowedGenres: string[];
   minimumConfidence: number;
@@ -104,7 +106,7 @@ export class GeminiConcertExtractorService {
     const apiKey = this.configService.get<string>('GEMINI_API_KEY')?.trim();
     const model =
       this.configService.get<string>('GEMINI_MODEL')?.trim() ||
-      'gemini-2.0-flash';
+      DEFAULT_GEMINI_MODEL;
 
     if (!this.isGeminiEnabled()) {
       return this.buildHeuristicExtraction(event, {

--- a/src/health/health.service.spec.ts
+++ b/src/health/health.service.spec.ts
@@ -19,7 +19,7 @@ describe('HealthService', () => {
         'sync-doctor-calendar@nido-api.iam.gserviceaccount.com',
       GOOGLE_CALENDAR_SERVICE_ACCOUNT_PRIVATE_KEY: 'set',
       GEMINI_API_KEY: 'set',
-      GEMINI_MODEL: 'gemini-2.0-flash',
+      GEMINI_MODEL: 'gemini-2.5-flash',
       ...options?.env,
     };
     const dataSource = {


### PR DESCRIPTION
## Summary

- Fixes the admin ingestion approval flow so approving a flyer publishes or updates a linked concert in the shared events feed.
- Refreshes the Events page when concerts change so newly approved future shows appear without stale UI state.
- Improves the admin review modal layout with one publish field per line, scrollable modal content, and visible sticky actions.
- Updates Gemini sync config to default to `gemini-2.5-flash` while keeping Gemini extraction disabled in dev by default.
- Updates deployment docs and dev workflow config so future deploys preserve the validated runtime settings.

## Validation

- GitHub Actions `Validate Deployment` completed successfully for the PR head.
- Verified live dev Events page showed the approved future Eno River show during manual testing.
- Verified Firebase Hosting served the latest frontend bundle during manual testing.
- Ran targeted backend tests: `npm test -- --runTestsByPath src/concert-sync/services/gemini-concert-extractor.service.spec.ts src/health/health.service.spec.ts`.
- Ran frontend production build: `npm run build --prefix client`.

## Deployment Notes

- Dev Cloud Run should keep `CONCERT_SYNC_GEMINI_ENABLED=false`.
- Dev deploy workflow now uses `GEMINI_MODEL=gemini-2.5-flash`.
- Approved uploads only appear in public Events when the concert start time is in the future because `/events` filters with `startsAfter=<current time>`.

## Dev Smoke Test

1. Sign in to the dev frontend as an admin email.
2. Upload a flyer through the Events intake.
3. Open `/admin/ingestion/uploads`.
4. Approve the upload with title plus future date/time.
5. Confirm the modal closes and the row reloads as approved.
6. Open `/events` and confirm the approved future show appears in the public list.