### PR TITLE
feat: implement Artist domain and REST APIs

### DIFF
--- a/src/apis/artists/artist.controller.ts
+++ b/src/apis/artists/artist.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Query,
+  Body,
+  UseGuards,
+  HttpCode,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ArtistService } from './artist.service';
+import { Artist } from './entities/artist.entity';
+import { ListArtistsDto } from './dto/list-artists.dto';
+import { ArtistResponseDto } from './dto/artist-response.dto';
+import { CreateArtistDto } from './dto/create-artist.dto';
+import { UpdateArtistDto } from './dto/update-artist.dto';
+import { FirebaseAuthGuard } from '../../auth/firebase-auth/firebase-auth.guard';
+import { AdminEmailGuard } from '../../auth/guards/admin-email.guard';
+
+@Controller('artists')
+@ApiTags('Artists')
+export class ArtistController {
+  constructor(private readonly artistService: ArtistService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all artists, optionally filtered by search or genre tag' })
+  @ApiOkResponse({ description: 'List of artists', type: [ArtistResponseDto] })
+  async findAll(@Query() query: ListArtistsDto): Promise<Artist[]> {
+    return this.artistService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get an artist by ID' })
+  @ApiOkResponse({ description: 'Artist details', type: ArtistResponseDto })
+  async findOne(@Param('id') id: string): Promise<Artist> {
+    return this.artistService.findOne(id);
+  }
+
+  @Get(':slug/slug')
+  @ApiOperation({ summary: 'Get an artist by URL-friendly slug' })
+  @ApiOkResponse({ description: 'Artist details', type: ArtistResponseDto })
+  async findBySlug(@Param('slug') slug: string): Promise<Artist> {
+    return this.artistService.findBySlug(slug);
+  }
+
+  @Post()
+  @UseGuards(FirebaseAuthGuard, AdminEmailGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new artist profile (Admin only)' })
+  @ApiCreatedResponse({ description: 'The artist profile has been successfully created.', type: ArtistResponseDto })
+  async create(@Body() createArtistDto: CreateArtistDto): Promise<Artist> {
+    return this.artistService.create(createArtistDto);
+  }
+
+  @Put(':id')
+  @UseGuards(FirebaseAuthGuard, AdminEmailGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update an artist profile by ID (Admin only)' })
+  @ApiOkResponse({ description: 'The artist profile has been successfully updated.', type: ArtistResponseDto })
+  async update(
+    @Param('id') id: string,
+    @Body() updateArtistDto: UpdateArtistDto,
+  ): Promise<Artist> {
+    return this.artistService.update(id, updateArtistDto);
+  }
+
+  @Delete(':id')
+  @UseGuards(FirebaseAuthGuard, AdminEmailGuard)
+  @ApiBearerAuth()
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Delete an artist profile by ID (Admin only)' })
+  async remove(@Param('id') id: string): Promise<void> {
+    await this.artistService.remove(id);
+  }
+}

--- a/src/apis/artists/artist.module.ts
+++ b/src/apis/artists/artist.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Artist } from './entities/artist.entity';
+import { ArtistService } from './artist.service';
+import { ArtistController } from './artist.controller';
+import { AuthModule } from '../../auth/auth.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Artist]),
+    AuthModule,
+  ],
+  controllers: [ArtistController],
+  providers: [ArtistService],
+  exports: [ArtistService],
+})
+export class ArtistModule {}

--- a/src/apis/artists/artist.service.spec.ts
+++ b/src/apis/artists/artist.service.spec.ts
@@ -10,6 +10,7 @@ describe('ArtistService', () => {
   let repository: Repository<Artist>;
 
   const mockQueryBuilder = {
+    where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     getMany: jest.fn(),
@@ -151,6 +152,27 @@ describe('ArtistService', () => {
 
       expect(mockArtistRepository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
       expect(mockArtistRepository.remove).toHaveBeenCalledWith(artist);
+    });
+  });
+
+  describe('findOrCreateManyByName', () => {
+    it('should return empty list on empty inputs', async () => {
+      const result = await service.findOrCreateManyByName([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should find existing and create missing artists', async () => {
+      const existing = { id: 'uuid-1', name: 'The Floozies', slug: 'the-floozies' } as unknown as Artist;
+      const created = { id: 'uuid-2', name: 'Defunk', slug: 'defunk' } as unknown as Artist;
+
+      mockQueryBuilder.getMany.mockResolvedValue([existing]);
+      mockArtistRepository.findOne.mockResolvedValue(null);
+      mockArtistRepository.create.mockReturnValue(created);
+      mockArtistRepository.save.mockResolvedValue(created);
+
+      const result = await service.findOrCreateManyByName(['The Floozies', 'Defunk']);
+
+      expect(result).toEqual([existing, created]);
     });
   });
 });

--- a/src/apis/artists/artist.service.spec.ts
+++ b/src/apis/artists/artist.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { ArtistService } from './artist.service';
+import { Artist } from './entities/artist.entity';
+
+describe('ArtistService', () => {
+  let service: ArtistService;
+  let repository: Repository<Artist>;
+
+  const mockQueryBuilder = {
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+  };
+
+  const mockArtistRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    merge: jest.fn((target, source) => Object.assign(target, source)),
+    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArtistService,
+        {
+          provide: getRepositoryToken(Artist),
+          useValue: mockArtistRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ArtistService>(ArtistService);
+    repository = module.get<Repository<Artist>>(getRepositoryToken(Artist));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should successfully create and save an artist with auto-generated slug', async () => {
+      const dto = { name: 'The Floozies', genres: ['Electronic', 'Funk'] };
+      const artist = { id: 'uuid', ...dto, slug: 'the-floozies' } as unknown as Artist;
+
+      mockArtistRepository.findOne.mockResolvedValue(null);
+      mockArtistRepository.create.mockReturnValue(artist);
+      mockArtistRepository.save.mockResolvedValue(artist);
+
+      const result = await service.create(dto);
+
+      expect(mockArtistRepository.findOne).toHaveBeenCalledWith({ where: { slug: 'the-floozies' } });
+      expect(mockArtistRepository.create).toHaveBeenCalledWith({
+        ...dto,
+        slug: 'the-floozies',
+        genres: ['electronic', 'funk'],
+      });
+      expect(mockArtistRepository.save).toHaveBeenCalledWith(artist);
+      expect(result).toEqual(artist);
+    });
+
+    it('should throw ConflictException if slug already exists', async () => {
+      const dto = { name: 'The Floozies' };
+      mockArtistRepository.findOne.mockResolvedValue({ id: 'existing-id' } as unknown as Artist);
+
+      await expect(service.create(dto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should query and return artists list', async () => {
+      const artists = [{ id: '1', name: 'B Band' }, { id: '2', name: 'A Band' }];
+      mockQueryBuilder.getMany.mockResolvedValue(artists);
+
+      const result = await service.findAll({ q: 'Band', genre: 'Funk', isFeatured: true });
+
+      expect(mockArtistRepository.createQueryBuilder).toHaveBeenCalledWith('artist');
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('artist.name ILIKE :q', { q: '%Band%' });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(':genre = ANY(artist.genres)', { genre: 'funk' });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('artist.isFeatured = :isFeatured', { isFeatured: true });
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('artist.name', 'ASC');
+      expect(result).toEqual(artists);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return artist by id', async () => {
+      const artist = { id: '1', name: 'B Band' } as unknown as Artist;
+      mockArtistRepository.findOne.mockResolvedValue(artist);
+
+      const result = await service.findOne('1');
+
+      expect(mockArtistRepository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+      expect(result).toEqual(artist);
+    });
+
+    it('should throw NotFoundException if artist not found by id', async () => {
+      mockArtistRepository.findOne.mockResolvedValue(null);
+      await expect(service.findOne('1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('should return artist by slug', async () => {
+      const artist = { id: '1', name: 'B Band', slug: 'b-band' } as unknown as Artist;
+      mockArtistRepository.findOne.mockResolvedValue(artist);
+
+      const result = await service.findBySlug('b-band');
+
+      expect(mockArtistRepository.findOne).toHaveBeenCalledWith({ where: { slug: 'b-band' } });
+      expect(result).toEqual(artist);
+    });
+
+    it('should throw NotFoundException if artist not found by slug', async () => {
+      mockArtistRepository.findOne.mockResolvedValue(null);
+      await expect(service.findBySlug('b-band')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should successfully update artist properties and regenerate slug', async () => {
+      const existing = { id: '1', name: 'Old Band', slug: 'old-band', genres: [] } as unknown as Artist;
+      const dto = { name: 'New Band' };
+      const updated = { id: '1', name: 'New Band', slug: 'new-band', genres: [] } as unknown as Artist;
+
+      mockArtistRepository.findOne
+        .mockResolvedValueOnce(existing) // findOne in update
+        .mockResolvedValueOnce(null);    // duplicate slug check findOne
+
+      mockArtistRepository.save.mockResolvedValue(updated);
+
+      const result = await service.update('1', dto);
+
+      expect(mockArtistRepository.save).toHaveBeenCalledWith(updated);
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('remove', () => {
+    it('should successfully delete an artist', async () => {
+      const artist = { id: '1', name: 'B Band' } as unknown as Artist;
+      mockArtistRepository.findOne.mockResolvedValue(artist);
+      mockArtistRepository.remove.mockResolvedValue(artist);
+
+      await service.remove('1');
+
+      expect(mockArtistRepository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+      expect(mockArtistRepository.remove).toHaveBeenCalledWith(artist);
+    });
+  });
+});

--- a/src/apis/artists/artist.service.ts
+++ b/src/apis/artists/artist.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Artist } from './entities/artist.entity';
+import { CreateArtistDto } from './dto/create-artist.dto';
+import { UpdateArtistDto } from './dto/update-artist.dto';
+
+function slugify(text: string): string {
+  return text
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w\-]+/g, '')
+    .replace(/\-\-+/g, '-');
+}
+
+@Injectable()
+export class ArtistService {
+  constructor(
+    @InjectRepository(Artist)
+    private readonly artistRepository: Repository<Artist>,
+  ) {}
+
+  async create(dto: CreateArtistDto): Promise<Artist> {
+    const slug = dto.slug ? slugify(dto.slug) : slugify(dto.name);
+    
+    const existing = await this.artistRepository.findOne({ where: { slug } });
+    if (existing) {
+      throw new ConflictException(`Artist with slug "${slug}" already exists`);
+    }
+
+    const artist = this.artistRepository.create({
+      ...dto,
+      slug,
+      genres: dto.genres?.map(g => g.toLowerCase()) ?? [],
+    });
+
+    return this.artistRepository.save(artist);
+  }
+
+  async findAll(query?: { q?: string; genre?: string; isFeatured?: boolean }): Promise<Artist[]> {
+    const qb = this.artistRepository.createQueryBuilder('artist');
+
+    if (query?.q) {
+      qb.andWhere('artist.name ILIKE :q', { q: `%${query.q}%` });
+    }
+
+    if (query?.genre) {
+      qb.andWhere(':genre = ANY(artist.genres)', { genre: query.genre.toLowerCase() });
+    }
+
+    if (query?.isFeatured !== undefined) {
+      qb.andWhere('artist.isFeatured = :isFeatured', { isFeatured: query.isFeatured });
+    }
+
+    qb.orderBy('artist.name', 'ASC');
+    return qb.getMany();
+  }
+
+  async findOne(id: string): Promise<Artist> {
+    const artist = await this.artistRepository.findOne({ where: { id } });
+    if (!artist) {
+      throw new NotFoundException(`Artist with ID "${id}" not found`);
+    }
+    return artist;
+  }
+
+  async findBySlug(slug: string): Promise<Artist> {
+    const artist = await this.artistRepository.findOne({ where: { slug } });
+    if (!artist) {
+      throw new NotFoundException(`Artist with slug "${slug}" not found`);
+    }
+    return artist;
+  }
+
+  async update(id: string, dto: UpdateArtistDto): Promise<Artist> {
+    const artist = await this.findOne(id);
+
+    if (dto.name && !dto.slug) {
+      const newSlug = slugify(dto.name);
+      if (newSlug !== artist.slug) {
+        const existing = await this.artistRepository.findOne({ where: { slug: newSlug } });
+        if (existing && existing.id !== id) {
+          throw new ConflictException(`Artist with slug "${newSlug}" already exists`);
+        }
+        artist.slug = newSlug;
+      }
+    } else if (dto.slug) {
+      const newSlug = slugify(dto.slug);
+      if (newSlug !== artist.slug) {
+        const existing = await this.artistRepository.findOne({ where: { slug: newSlug } });
+        if (existing && existing.id !== id) {
+          throw new ConflictException(`Artist with slug "${newSlug}" already exists`);
+        }
+        artist.slug = newSlug;
+      }
+    }
+
+    this.artistRepository.merge(artist, {
+      ...dto,
+      genres: dto.genres?.map(g => g.toLowerCase()) ?? artist.genres,
+    });
+
+    return this.artistRepository.save(artist);
+  }
+
+  async remove(id: string): Promise<void> {
+    const artist = await this.findOne(id);
+    await this.artistRepository.remove(artist);
+  }
+}

--- a/src/apis/artists/artist.service.ts
+++ b/src/apis/artists/artist.service.ts
@@ -109,4 +109,54 @@ export class ArtistService {
     const artist = await this.findOne(id);
     await this.artistRepository.remove(artist);
   }
+
+  async findOrCreateManyByName(names: string[]): Promise<Artist[]> {
+    if (!names || names.length === 0) return [];
+
+    const normalizedNames = names
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+
+    if (normalizedNames.length === 0) return [];
+
+    const existing = await this.artistRepository
+      .createQueryBuilder('artist')
+      .where('LOWER(artist.name) IN (:...names)', {
+        names: normalizedNames.map((n) => n.toLowerCase()),
+      })
+      .getMany();
+
+    const existingMap = new Map(existing.map((a) => [a.name.toLowerCase(), a]));
+    const results: Artist[] = [];
+
+    for (const name of normalizedNames) {
+      const lowerName = name.toLowerCase();
+      const found = existingMap.get(lowerName);
+      if (found) {
+        results.push(found);
+      } else {
+        let baseSlug = slugify(name);
+        if (!baseSlug) {
+          baseSlug = 'artist';
+        }
+        let slug = baseSlug;
+        let counter = 1;
+        while (await this.artistRepository.findOne({ where: { slug } })) {
+          slug = `${baseSlug}-${counter}`;
+          counter++;
+        }
+
+        const newArtist = this.artistRepository.create({
+          name,
+          slug,
+          genres: [],
+        });
+        const saved = await this.artistRepository.save(newArtist);
+        results.push(saved);
+        existingMap.set(lowerName, saved);
+      }
+    }
+
+    return results;
+  }
 }

--- a/src/apis/artists/dto/artist-response.dto.ts
+++ b/src/apis/artists/dto/artist-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ArtistResponseDto {
+  @ApiProperty({ description: 'The unique UUID of the artist', example: 'd3b07384-d113-41e8-ae36-418ae1688d35' })
+  id: string;
+
+  @ApiProperty({ description: 'The name of the artist / band', example: 'The Floozies' })
+  name: string;
+
+  @ApiProperty({ description: 'Unique slug used for routing and matching', example: 'the-floozies' })
+  slug: string;
+
+  @ApiPropertyOptional({ description: 'Array of genres', example: ['funk', 'electronic'], nullable: true })
+  genres: string[] | null;
+
+  @ApiPropertyOptional({ description: 'Square or landscape promo photo URL', example: 'https://example.com/artist.jpg', nullable: true })
+  promoImageUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Spotify artist page URL', example: 'https://open.spotify.com/artist/123', nullable: true })
+  spotifyUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Instagram handle', example: 'flooziesduo', nullable: true })
+  instagramHandle?: string | null;
+
+  @ApiPropertyOptional({ description: 'Official band website URL', example: 'https://flooziesduo.com', nullable: true })
+  websiteUrl?: string | null;
+
+  @ApiProperty({ description: 'Flag to prioritize artist in curation feeds', example: false })
+  isFeatured: boolean;
+
+  @ApiProperty({ description: 'Record creation timestamp', example: '2026-06-16T01:00:00.000Z' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Record update timestamp', example: '2026-06-16T01:00:00.000Z' })
+  updatedAt: string;
+}

--- a/src/apis/artists/dto/create-artist.dto.ts
+++ b/src/apis/artists/dto/create-artist.dto.ts
@@ -1,0 +1,45 @@
+import { IsNotEmpty, IsOptional, IsString, IsArray, IsBoolean, IsUrl } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateArtistDto {
+  @ApiProperty({ description: 'The name of the artist / band', example: 'The Floozies' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Optional unique slug (auto-generated if omitted)', example: 'the-floozies' })
+  @IsOptional()
+  @IsString()
+  slug?: string;
+
+  @ApiPropertyOptional({ description: 'Array of genre tags', example: ['funk', 'electronic'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  genres?: string[];
+
+  @ApiPropertyOptional({ description: 'GCS or public promotional photo URL', example: 'https://example.com/artist.jpg' })
+  @IsOptional()
+  @IsUrl()
+  promoImageUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Spotify artist page URL', example: 'https://open.spotify.com/artist/123' })
+  @IsOptional()
+  @IsUrl()
+  spotifyUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Instagram handle', example: 'flooziesduo' })
+  @IsOptional()
+  @IsString()
+  instagramHandle?: string;
+
+  @ApiPropertyOptional({ description: 'Official band website URL', example: 'https://flooziesduo.com' })
+  @IsOptional()
+  @IsUrl()
+  websiteUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Flag to prioritize artist in curation feeds', example: false })
+  @IsOptional()
+  @IsBoolean()
+  isFeatured?: boolean;
+}

--- a/src/apis/artists/dto/list-artists.dto.ts
+++ b/src/apis/artists/dto/list-artists.dto.ts
@@ -1,0 +1,21 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class ListArtistsDto {
+  @ApiPropertyOptional({ description: 'Fuzzy search by artist name' })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by genre tag' })
+  @IsOptional()
+  @IsString()
+  genre?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by featured artists' })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  isFeatured?: boolean;
+}

--- a/src/apis/artists/dto/update-artist.dto.ts
+++ b/src/apis/artists/dto/update-artist.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateArtistDto } from './create-artist.dto';
+
+export class UpdateArtistDto extends PartialType(CreateArtistDto) {}

--- a/src/apis/artists/entities/artist.entity.ts
+++ b/src/apis/artists/entities/artist.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity({ name: 'artists' })
+export class Artist {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ unique: true })
+  @Index('IDX_artists_slug')
+  slug: string;
+
+  @Column('text', { array: true, nullable: true })
+  genres: string[];
+
+  @Column({ name: 'promo_image_url', nullable: true })
+  promoImageUrl?: string;
+
+  @Column({ name: 'spotify_url', nullable: true })
+  spotifyUrl?: string;
+
+  @Column({ name: 'instagram_handle', nullable: true })
+  instagramHandle?: string;
+
+  @Column({ name: 'website_url', nullable: true })
+  websiteUrl?: string;
+
+  @Column({ name: 'is_featured', default: false })
+  isFeatured: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { FirebaseModule } from './firebase/firebase.module';
 import { AuthModule } from './auth/auth.module';
 import { ConcertModule } from './apis/concerts/concert.module';
 import { VenueModule } from './apis/venues/venue.module';
+import { ArtistModule } from './apis/artists/artist.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { IngestionModule } from './ingestion/ingestion.module';
 import { ConcertSyncModule } from './concert-sync/concert-sync.module';
@@ -36,6 +37,7 @@ import { HealthModule } from './health/health.module';
     AuthModule,
     ConcertModule,
     VenueModule,
+    ArtistModule,
     IngestionModule,
     ConcertSyncModule,
     HealthModule,


### PR DESCRIPTION
### Proposed Changes
This PR implements **Issue 1.2: Artist Domain & Setup** of Sprint 1:
1. **Artist Domain**:
   - Implemented `Artist` database entity with fields for name, slug, genres, promo image, and social media/website links.
   - Built full CRUD operations, slug uniqueness handling, and search/featured filters in `ArtistService` and `ArtistController`.
2. **Module Registration**:
   - Registered `ArtistModule` in `AppModule`.
3. **Verification**:
   - Added complete unit test coverage for the service. All 76 tests in the project pass successfully.