### PR TITLE
feat: implement Band domain and REST APIs

### DIFF
--- a/src/apis/bands/band.controller.ts
+++ b/src/apis/bands/band.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Query,
+  Body,
+  UseGuards,
+  HttpCode,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { BandService } from './band.service';
+import { Band } from './entities/band.entity';
+import { ListBandsDto } from './dto/list-bands.dto';
+import { BandResponseDto } from './dto/band-response.dto';
+import { CreateBandDto } from './dto/create-band.dto';
+import { UpdateBandDto } from './dto/update-band.dto';
+import { FirebaseAuthGuard } from '../../auth/firebase-auth/firebase-auth.guard';
+import { AdminEmailGuard } from '../../auth/guards/admin-email.guard';
+
+@Controller('bands')
+@ApiTags('Bands')
+export class BandController {
+  constructor(private readonly bandService: BandService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all bands, optionally filtered by search query or genre tag' })
+  @ApiOkResponse({ description: 'List of bands', type: [BandResponseDto] })
+  async findAll(@Query() query: ListBandsDto): Promise<Band[]> {
+    return this.bandService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a band by ID' })
+  @ApiOkResponse({ description: 'Band details', type: BandResponseDto })
+  async findOne(@Param('id') id: string): Promise<Band> {
+    return this.bandService.findOne(id);
+  }
+
+  @Get(':slug/slug')
+  @ApiOperation({ summary: 'Get a band by URL-friendly slug' })
+  @ApiOkResponse({ description: 'Band details', type: BandResponseDto })
+  async findBySlug(@Param('slug') slug: string): Promise<Band> {
+    return this.bandService.findBySlug(slug);
+  }
+
+  @Post()
+  @UseGuards(FirebaseAuthGuard, AdminEmailGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new band profile (Admin only)' })
+  @ApiCreatedResponse({ description: 'The band profile has been successfully created.', type: BandResponseDto })
+  async create(@Body() createBandDto: CreateBandDto): Promise<Band> {
+    return this.bandService.create(createBandDto);
+  }
+
+  @Put(':id')
+  @UseGuards(FirebaseAuthGuard, AdminEmailGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a band profile by ID (Admin only)' })
+  @ApiOkResponse({ description: 'The band profile has been successfully updated.', type: BandResponseDto })
+  async update(
+    @Param('id') id: string,
+    @Body() updateBandDto: UpdateBandDto,
+  ): Promise<Band> {
+    return this.bandService.update(id, updateBandDto);
+  }
+
+  @Delete(':id')
+  @UseGuards(FirebaseAuthGuard, AdminEmailGuard)
+  @ApiBearerAuth()
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Delete a band profile by ID (Admin only)' })
+  async remove(@Param('id') id: string): Promise<void> {
+    await this.bandService.remove(id);
+  }
+}

--- a/src/apis/bands/band.module.ts
+++ b/src/apis/bands/band.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Band } from './entities/band.entity';
+import { BandService } from './band.service';
+import { BandController } from './band.controller';
+import { AuthModule } from '../../auth/auth.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Band]),
+    AuthModule,
+  ],
+  controllers: [BandController],
+  providers: [BandService],
+  exports: [BandService],
+})
+export class BandModule {}

--- a/src/apis/bands/band.service.spec.ts
+++ b/src/apis/bands/band.service.spec.ts
@@ -1,0 +1,178 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { BandService } from './band.service';
+import { Band } from './entities/band.entity';
+
+describe('BandService', () => {
+  let service: BandService;
+  let repository: Repository<Band>;
+
+  const mockQueryBuilder = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+  };
+
+  const mockBandRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    merge: jest.fn((target, source) => Object.assign(target, source)),
+    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BandService,
+        {
+          provide: getRepositoryToken(Band),
+          useValue: mockBandRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<BandService>(BandService);
+    repository = module.get<Repository<Band>>(getRepositoryToken(Band));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should successfully create and save a band with auto-generated slug', async () => {
+      const dto = { name: 'The Floozies', genres: ['Electronic', 'Funk'] };
+      const band = { id: 'uuid', ...dto, slug: 'the-floozies' } as unknown as Band;
+
+      mockBandRepository.findOne.mockResolvedValue(null);
+      mockBandRepository.create.mockReturnValue(band);
+      mockBandRepository.save.mockResolvedValue(band);
+
+      const result = await service.create(dto);
+
+      expect(mockBandRepository.findOne).toHaveBeenCalledWith({ where: { slug: 'the-floozies' } });
+      expect(mockBandRepository.create).toHaveBeenCalledWith({
+        ...dto,
+        slug: 'the-floozies',
+        genres: ['electronic', 'funk'],
+      });
+      expect(mockBandRepository.save).toHaveBeenCalledWith(band);
+      expect(result).toEqual(band);
+    });
+
+    it('should throw ConflictException if slug already exists', async () => {
+      const dto = { name: 'The Floozies' };
+      mockBandRepository.findOne.mockResolvedValue({ id: 'existing-id' } as unknown as Band);
+
+      await expect(service.create(dto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should query and return bands list', async () => {
+      const bands = [{ id: '1', name: 'B Band' }, { id: '2', name: 'A Band' }];
+      mockQueryBuilder.getMany.mockResolvedValue(bands);
+
+      const result = await service.findAll({ q: 'Band', genre: 'Funk', isFeatured: true });
+
+      expect(mockBandRepository.createQueryBuilder).toHaveBeenCalledWith('band');
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('band.name ILIKE :q', { q: '%Band%' });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(':genre = ANY(band.genres)', { genre: 'funk' });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('band.isFeatured = :isFeatured', { isFeatured: true });
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('band.name', 'ASC');
+      expect(result).toEqual(bands);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return band by id', async () => {
+      const band = { id: '1', name: 'B Band' } as unknown as Band;
+      mockBandRepository.findOne.mockResolvedValue(band);
+
+      const result = await service.findOne('1');
+
+      expect(mockBandRepository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+      expect(result).toEqual(band);
+    });
+
+    it('should throw NotFoundException if band not found by id', async () => {
+      mockBandRepository.findOne.mockResolvedValue(null);
+      await expect(service.findOne('1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('should return band by slug', async () => {
+      const band = { id: '1', name: 'B Band', slug: 'b-band' } as unknown as Band;
+      mockBandRepository.findOne.mockResolvedValue(band);
+
+      const result = await service.findBySlug('b-band');
+
+      expect(mockBandRepository.findOne).toHaveBeenCalledWith({ where: { slug: 'b-band' } });
+      expect(result).toEqual(band);
+    });
+
+    it('should throw NotFoundException if band not found by slug', async () => {
+      mockBandRepository.findOne.mockResolvedValue(null);
+      await expect(service.findBySlug('b-band')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should successfully update band properties and regenerate slug', async () => {
+      const existing = { id: '1', name: 'Old Band', slug: 'old-band', genres: [] } as unknown as Band;
+      const dto = { name: 'New Band' };
+      const updated = { id: '1', name: 'New Band', slug: 'new-band', genres: [] } as unknown as Band;
+
+      mockBandRepository.findOne
+        .mockResolvedValueOnce(existing) // findOne in update
+        .mockResolvedValueOnce(null);    // duplicate slug check findOne
+
+      mockBandRepository.save.mockResolvedValue(updated);
+
+      const result = await service.update('1', dto);
+
+      expect(mockBandRepository.save).toHaveBeenCalledWith(updated);
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('remove', () => {
+    it('should successfully delete a band', async () => {
+      const band = { id: '1', name: 'B Band' } as unknown as Band;
+      mockBandRepository.findOne.mockResolvedValue(band);
+      mockBandRepository.remove.mockResolvedValue(band);
+
+      await service.remove('1');
+
+      expect(mockBandRepository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+      expect(mockBandRepository.remove).toHaveBeenCalledWith(band);
+    });
+  });
+
+  describe('findOrCreateManyByName', () => {
+    it('should return empty list on empty inputs', async () => {
+      const result = await service.findOrCreateManyByName([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should find existing and create missing bands', async () => {
+      const existing = { id: 'uuid-1', name: 'The Floozies', slug: 'the-floozies' } as unknown as Band;
+      const created = { id: 'uuid-2', name: 'Defunk', slug: 'defunk' } as unknown as Band;
+
+      mockQueryBuilder.getMany.mockResolvedValue([existing]);
+      mockBandRepository.findOne.mockResolvedValue(null);
+      mockBandRepository.create.mockReturnValue(created);
+      mockBandRepository.save.mockResolvedValue(created);
+
+      const result = await service.findOrCreateManyByName(['The Floozies', 'Defunk']);
+
+      expect(result).toEqual([existing, created]);
+    });
+  });
+});

--- a/src/apis/bands/band.service.ts
+++ b/src/apis/bands/band.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Band } from './entities/band.entity';
+import { CreateBandDto } from './dto/create-band.dto';
+import { UpdateBandDto } from './dto/update-band.dto';
+
+function slugify(text: string): string {
+  return text
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w\-]+/g, '')
+    .replace(/\-\-+/g, '-');
+}
+
+@Injectable()
+export class BandService {
+  constructor(
+    @InjectRepository(Band)
+    private readonly bandRepository: Repository<Band>,
+  ) {}
+
+  async create(dto: CreateBandDto): Promise<Band> {
+    const slug = dto.slug ? slugify(dto.slug) : slugify(dto.name);
+    
+    const existing = await this.bandRepository.findOne({ where: { slug } });
+    if (existing) {
+      throw new ConflictException(`Band with slug "${slug}" already exists`);
+    }
+
+    const band = this.bandRepository.create({
+      ...dto,
+      slug,
+      genres: dto.genres?.map(g => g.toLowerCase()) ?? [],
+    });
+
+    return this.bandRepository.save(band);
+  }
+
+  async findAll(query?: { q?: string; genre?: string; isFeatured?: boolean }): Promise<Band[]> {
+    const qb = this.bandRepository.createQueryBuilder('band');
+
+    if (query?.q) {
+      qb.andWhere('band.name ILIKE :q', { q: `%${query.q}%` });
+    }
+
+    if (query?.genre) {
+      qb.andWhere(':genre = ANY(band.genres)', { genre: query.genre.toLowerCase() });
+    }
+
+    if (query?.isFeatured !== undefined) {
+      qb.andWhere('band.isFeatured = :isFeatured', { isFeatured: query.isFeatured });
+    }
+
+    qb.orderBy('band.name', 'ASC');
+    return qb.getMany();
+  }
+
+  async findOne(id: string): Promise<Band> {
+    const band = await this.bandRepository.findOne({ where: { id } });
+    if (!band) {
+      throw new NotFoundException(`Band with ID "${id}" not found`);
+    }
+    return band;
+  }
+
+  async findBySlug(slug: string): Promise<Band> {
+    const band = await this.bandRepository.findOne({ where: { slug } });
+    if (!band) {
+      throw new NotFoundException(`Band with slug "${slug}" not found`);
+    }
+    return band;
+  }
+
+  async update(id: string, dto: UpdateBandDto): Promise<Band> {
+    const band = await this.findOne(id);
+
+    if (dto.name && !dto.slug) {
+      const newSlug = slugify(dto.name);
+      if (newSlug !== band.slug) {
+        const existing = await this.bandRepository.findOne({ where: { slug: newSlug } });
+        if (existing && existing.id !== id) {
+          throw new ConflictException(`Band with slug "${newSlug}" already exists`);
+        }
+        band.slug = newSlug;
+      }
+    } else if (dto.slug) {
+      const newSlug = slugify(dto.slug);
+      if (newSlug !== band.slug) {
+        const existing = await this.bandRepository.findOne({ where: { slug: newSlug } });
+        if (existing && existing.id !== id) {
+          throw new ConflictException(`Band with slug "${newSlug}" already exists`);
+        }
+        band.slug = newSlug;
+      }
+    }
+
+    this.bandRepository.merge(band, {
+      ...dto,
+      genres: dto.genres?.map(g => g.toLowerCase()) ?? band.genres,
+    });
+
+    return this.bandRepository.save(band);
+  }
+
+  async remove(id: string): Promise<void> {
+    const band = await this.findOne(id);
+    await this.bandRepository.remove(band);
+  }
+
+  async findOrCreateManyByName(names: string[]): Promise<Band[]> {
+    if (!names || names.length === 0) return [];
+
+    const normalizedNames = names
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+
+    if (normalizedNames.length === 0) return [];
+
+    const existing = await this.bandRepository
+      .createQueryBuilder('band')
+      .where('LOWER(band.name) IN (:...names)', {
+        names: normalizedNames.map((n) => n.toLowerCase()),
+      })
+      .getMany();
+
+    const existingMap = new Map(existing.map((b) => [b.name.toLowerCase(), b]));
+    const results: Band[] = [];
+
+    for (const name of normalizedNames) {
+      const lowerName = name.toLowerCase();
+      const found = existingMap.get(lowerName);
+      if (found) {
+        results.push(found);
+      } else {
+        let baseSlug = slugify(name);
+        if (!baseSlug) {
+          baseSlug = 'band';
+        }
+        let slug = baseSlug;
+        let counter = 1;
+        while (await this.bandRepository.findOne({ where: { slug } })) {
+          slug = `${baseSlug}-${counter}`;
+          counter++;
+        }
+
+        const newBand = this.bandRepository.create({
+          name,
+          slug,
+          genres: [],
+        });
+        const saved = await this.bandRepository.save(newBand);
+        results.push(saved);
+        existingMap.set(lowerName, saved);
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/apis/bands/dto/band-response.dto.ts
+++ b/src/apis/bands/dto/band-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class BandResponseDto {
+  @ApiProperty({ description: 'The unique UUID of the band', example: 'd3b07384-d113-41e8-ae36-418ae1688d35' })
+  id: string;
+
+  @ApiProperty({ description: 'The name of the band / performer', example: 'The Floozies' })
+  name: string;
+
+  @ApiProperty({ description: 'Unique slug used for routing and matching', example: 'the-floozies' })
+  slug: string;
+
+  @ApiPropertyOptional({ description: 'Array of genres', example: ['funk', 'electronic'], nullable: true })
+  genres: string[] | null;
+
+  @ApiPropertyOptional({ description: 'Square or landscape promo photo URL', example: 'https://example.com/band.jpg', nullable: true })
+  promoImageUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Spotify band page URL', example: 'https://open.spotify.com/artist/123', nullable: true })
+  spotifyUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Instagram handle', example: 'flooziesduo', nullable: true })
+  instagramHandle?: string | null;
+
+  @ApiPropertyOptional({ description: 'Official band website URL', example: 'https://flooziesduo.com', nullable: true })
+  websiteUrl?: string | null;
+
+  @ApiProperty({ description: 'Flag to prioritize band in curation feeds', example: false })
+  isFeatured: boolean;
+
+  @ApiProperty({ description: 'Record creation timestamp', example: '2026-06-16T01:00:00.000Z' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Record update timestamp', example: '2026-06-16T01:00:00.000Z' })
+  updatedAt: string;
+}

--- a/src/apis/bands/dto/create-band.dto.ts
+++ b/src/apis/bands/dto/create-band.dto.ts
@@ -1,0 +1,45 @@
+import { IsNotEmpty, IsOptional, IsString, IsArray, IsBoolean, IsUrl } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateBandDto {
+  @ApiProperty({ description: 'The name of the band / performer', example: 'The Floozies' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Optional unique slug (auto-generated if omitted)', example: 'the-floozies' })
+  @IsOptional()
+  @IsString()
+  slug?: string;
+
+  @ApiPropertyOptional({ description: 'Array of genre tags', example: ['funk', 'electronic'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  genres?: string[];
+
+  @ApiPropertyOptional({ description: 'GCS or public promotional photo URL', example: 'https://example.com/band.jpg' })
+  @IsOptional()
+  @IsUrl()
+  promoImageUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Spotify artist/band page URL', example: 'https://open.spotify.com/artist/123' })
+  @IsOptional()
+  @IsUrl()
+  spotifyUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Instagram handle', example: 'flooziesduo' })
+  @IsOptional()
+  @IsString()
+  instagramHandle?: string;
+
+  @ApiPropertyOptional({ description: 'Official band website URL', example: 'https://flooziesduo.com' })
+  @IsOptional()
+  @IsUrl()
+  websiteUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Flag to prioritize band in curation feeds', example: false })
+  @IsOptional()
+  @IsBoolean()
+  isFeatured?: boolean;
+}

--- a/src/apis/bands/dto/list-bands.dto.ts
+++ b/src/apis/bands/dto/list-bands.dto.ts
@@ -1,0 +1,21 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class ListBandsDto {
+  @ApiPropertyOptional({ description: 'Fuzzy search by band name' })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by genre tag' })
+  @IsOptional()
+  @IsString()
+  genre?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by featured bands' })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  isFeatured?: boolean;
+}

--- a/src/apis/bands/dto/update-band.dto.ts
+++ b/src/apis/bands/dto/update-band.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateBandDto } from './create-band.dto';
+
+export class UpdateBandDto extends PartialType(CreateBandDto) {}

--- a/src/apis/bands/entities/band.entity.ts
+++ b/src/apis/bands/entities/band.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity({ name: 'bands' })
+export class Band {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ unique: true })
+  @Index('IDX_bands_slug')
+  slug: string;
+
+  @Column('text', { array: true, nullable: true })
+  genres: string[];
+
+  @Column({ name: 'promo_image_url', nullable: true })
+  promoImageUrl?: string;
+
+  @Column({ name: 'spotify_url', nullable: true })
+  spotifyUrl?: string;
+
+  @Column({ name: 'instagram_handle', nullable: true })
+  instagramHandle?: string;
+
+  @Column({ name: 'website_url', nullable: true })
+  websiteUrl?: string;
+
+  @Column({ name: 'is_featured', default: false })
+  isFeatured: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { FirebaseModule } from './firebase/firebase.module';
 import { AuthModule } from './auth/auth.module';
 import { ConcertModule } from './apis/concerts/concert.module';
 import { VenueModule } from './apis/venues/venue.module';
+import { BandModule } from './apis/bands/band.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { IngestionModule } from './ingestion/ingestion.module';
 import { ConcertSyncModule } from './concert-sync/concert-sync.module';
@@ -36,6 +37,7 @@ import { HealthModule } from './health/health.module';
     AuthModule,
     ConcertModule,
     VenueModule,
+    BandModule,
     IngestionModule,
     ConcertSyncModule,
     HealthModule,


### PR DESCRIPTION
## Overview
This PR implements **Issue 1.2: Band Domain & Setup** of Sprint 1 (Milestone 1). 

Following feedback, we have pivoted the terminology from `Artist` to `Band` (representing any musical act—both solo performers and multi-member groups) to map directly to live music conventions and support multi-act festival layouts. 

This module sets up the core CRUD endpoints and service handlers needed to associate performers to concert lineups in the next stage (Issue 1.3).

---

## What's Inside?

### 1. `Band` Entity & Database Schema
* **Location:** `src/apis/bands/entities/band.entity.ts`
* **Fields:** 
  * `id` (UUID, Primary Key)
  * `name` (VARCHAR, name of the band/act)
  * `slug` (VARCHAR, unique, indexed for SEO-friendly URLs, e.g. `the-floozies`)
  * `genres` (TEXT[], lowercase tags, e.g. `['funk', 'electronic']`)
  * `promoImageUrl` (VARCHAR, nullable)
  * `spotifyUrl` (VARCHAR, nullable)
  * `instagramHandle` (VARCHAR, nullable)
  * `websiteUrl` (VARCHAR, nullable)
  * `isFeatured` (BOOLEAN, defaults to `false` for curation tags)

### 2. Smart Bulk Performer Resolver
* **Location:** `src/apis/bands/band.service.ts`
* **Method:** `findOrCreateManyByName(names: string[])`
* **Why this is cool:** When parsing concert info from calendar syncs or Gemini flyer uploads, we receive a raw string array of names (e.g. `["The Floozies", "Defunk"]`). This method:
  1. Performs a case-insensitive query to resolve any existing bands.
  2. Auto-slugifies and generates unique slug counters (e.g. `band-1`) for any new performers.
  3. Bulk creates and inserts new records on-the-fly.
  4. Returns the full list of canonical `Band` entities for relational linking.

### 3. REST API Controllers
* **Location:** `src/apis/bands/band.controller.ts`
* **Endpoints:**
  * `GET /bands` - List all bands (supports fuzzy search, genre tags, and `isFeatured` filtering)
  * `GET /bands/:id` - Fetch detailed band profile by ID
  * `GET /bands/:slug/slug` - Fetch detailed band profile by URL slug
  * `POST /bands`, `PUT /bands/:id`, `DELETE /bands/:id` - Managed admin operations (guarded by `FirebaseAuthGuard` and `AdminEmailGuard`)

---

## How to Review & Test

### Run Unit Tests
A complete set of unit tests covers the creation, slug conflict resolution, query builder filters, and bulk lookup logic:
```bash
npm test
# (specifically checks: src/apis/bands/band.service.spec.ts)
```

### Swagger UI Check
Start the NestJS backend dev server:
```bash
npm run start:dev
```
Open **`http://localhost:3001/api`** in your browser. Under the **Bands** section, you will find all the documented endpoints decorated with validation metadata.

---

## What's Next?
In **Issue 1.3**, we will link this new `Band` domain to `Concert` lineups:
1. Alter `concerts` table to add a many-to-many relationship (`concert_bands` join table) mapped via `concert.lineup`.
2. Generate the unified migration script.