### PR TITLE
feat(concerts): add genre metadata endpoint

### DIFF
--- a/src/apis/concerts/concert.controller.http.spec.ts
+++ b/src/apis/concerts/concert.controller.http.spec.ts
@@ -13,6 +13,7 @@ describe('ConcertController HTTP contract', () => {
   let app: INestApplication;
   const concertService = {
     findAll: jest.fn(),
+    findAvailableGenres: jest.fn(),
   };
   const userService = {
     findExistingFromToken: jest.fn(),
@@ -80,5 +81,22 @@ describe('ConcertController HTTP contract', () => {
       expect.objectContaining({ sort: 'soonest', pageSize: 1 }),
       undefined,
     );
+  });
+
+  it('serves GET /concerts/meta/genres without a bearer token or user lookup', async () => {
+    concertService.findAvailableGenres.mockResolvedValue([
+      'Electronic',
+      'Indie Rock',
+      'Rock',
+    ]);
+
+    await request(app.getHttpServer())
+      .get('/concerts/meta/genres')
+      .expect(200)
+      .expect({ genres: ['Electronic', 'Indie Rock', 'Rock'] });
+
+    expect(userService.findExistingFromToken).not.toHaveBeenCalled();
+    expect(userService.syncFromToken).not.toHaveBeenCalled();
+    expect(concertService.findAvailableGenres).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/apis/concerts/concert.controller.ts
+++ b/src/apis/concerts/concert.controller.ts
@@ -35,6 +35,7 @@ import {
   ConcertListResponseDto,
   ConcertResponseDto,
 } from './dto/concert-response.dto';
+import { ConcertGenresResponseDto } from './dto/concert-genres-response.dto';
 
 @Controller('concerts')
 @ApiTags('Concerts')
@@ -167,6 +168,18 @@ export class ConcertController {
   ) {
     const owner = await this.ensureOwner(user);
     return this.concertService.removeUpvote(id, owner);
+  }
+
+  @Get('meta/genres')
+  @ApiOperation({
+    summary: 'List distinct concert genre values',
+    description:
+      'Returns the distinct, trimmed, non-empty genre values currently present on Concert records, sorted alphabetically. Public endpoint; does not require authentication and does not synchronize or look up a user. Capitalization is preserved so values remain compatible with the exact-match genre filter on GET /concerts. Example: GET /concerts/meta/genres.',
+  })
+  @ApiOkResponse({ type: ConcertGenresResponseDto })
+  async getAvailableGenres() {
+    const genres = await this.concertService.findAvailableGenres();
+    return { genres };
   }
 
   @Get(':id')

--- a/src/apis/concerts/concert.service.spec.ts
+++ b/src/apis/concerts/concert.service.spec.ts
@@ -32,6 +32,7 @@ const createQueryBuilderMock = () => {
   qb.getCount = jest.fn();
   qb.getRawAndEntities = jest.fn();
   qb.getRawOne = jest.fn();
+  qb.getRawMany = jest.fn();
   qb.execute = jest.fn();
   return qb;
 };
@@ -244,5 +245,47 @@ describe('ConcertService', () => {
       service.upvote('missing-concert', owner),
     ).rejects.toBeInstanceOf(NotFoundException);
     expect(concertUpvoteRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  describe('findAvailableGenres', () => {
+    it('deduplicates and alphabetically sorts genre values', async () => {
+      const qb = createQueryBuilderMock();
+      concertRepository.createQueryBuilder.mockReturnValue(qb);
+      qb.getRawMany.mockResolvedValue([
+        { genre: 'Rock' },
+        { genre: 'Electronic' },
+        { genre: 'Rock' },
+        { genre: 'Indie Rock' },
+      ]);
+
+      const result = await service.findAvailableGenres();
+
+      expect(result).toEqual(['Electronic', 'Indie Rock', 'Rock']);
+    });
+
+    it('excludes null, empty, and whitespace-only genre values', async () => {
+      const qb = createQueryBuilderMock();
+      concertRepository.createQueryBuilder.mockReturnValue(qb);
+      qb.getRawMany.mockResolvedValue([
+        { genre: 'Rock' },
+        { genre: null },
+        { genre: '' },
+        { genre: '   ' },
+      ]);
+
+      const result = await service.findAvailableGenres();
+
+      expect(result).toEqual(['Rock']);
+    });
+
+    it('returns an empty array when no genres are available', async () => {
+      const qb = createQueryBuilderMock();
+      concertRepository.createQueryBuilder.mockReturnValue(qb);
+      qb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.findAvailableGenres();
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/src/apis/concerts/concert.service.ts
+++ b/src/apis/concerts/concert.service.ts
@@ -47,6 +47,25 @@ export class ConcertService {
     return this.findWithQuery(qb, query, owner);
   }
 
+  async findAvailableGenres(): Promise<string[]> {
+    const rows = await this.concertRepository
+      .createQueryBuilder('concert')
+      .select('DISTINCT TRIM(concert.genre)', 'genre')
+      .where('concert.genre IS NOT NULL')
+      .andWhere("TRIM(concert.genre) <> ''")
+      .getRawMany<{ genre: string | null }>();
+
+    const genres = new Set<string>();
+    for (const row of rows) {
+      const genre = row.genre?.trim();
+      if (genre) {
+        genres.add(genre);
+      }
+    }
+
+    return Array.from(genres).sort((a, b) => a.localeCompare(b));
+  }
+
   private async findWithQuery(
     qb: ReturnType<Repository<Concert>['createQueryBuilder']>,
     query: ListConcertsDto,

--- a/src/apis/concerts/dto/concert-genres-response.dto.ts
+++ b/src/apis/concerts/dto/concert-genres-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConcertGenresResponseDto {
+  @ApiProperty({
+    description:
+      'Distinct, trimmed, non-empty Concert genre values currently in use, sorted alphabetically. Capitalization matches stored values so results remain compatible with the exact-match GET /concerts?genre= filter.',
+    type: [String],
+    example: ['Electronic', 'Indie Rock', 'Rock'],
+  })
+  genres: string[];
+}


### PR DESCRIPTION
## Summary

- add public `GET /concerts/meta/genres`
- return distinct, trimmed, non-empty genres in deterministic alphabetical order
- document the response with Swagger and add focused service/HTTP tests

## Validation

- `npm test -- --runInBand concerts`
- `npm run build`
- `git diff --check`

Live smoke testing was not run because this is a small read-only endpoint covered by focused HTTP/service tests and the Concert test suite.

Closes #48