### PR TITLE
Add optional genre dropdown to poster uploads

### DIFF
--- a/client/src/components/ingestion/IngestionUploadPanel.spec.ts
+++ b/client/src/components/ingestion/IngestionUploadPanel.spec.ts
@@ -1,0 +1,177 @@
+import {
+  enableAutoUnmount,
+  flushPromises,
+  mount,
+  type VueWrapper,
+} from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import IngestionUploadPanel from './IngestionUploadPanel.vue';
+
+const api = vi.hoisted(() => ({
+  createIngestionJob: vi.fn(),
+  fetchConcertGenres: vi.fn(),
+  fetchIngestionJob: vi.fn(),
+  uploadIngestionImage: vi.fn(),
+}));
+
+const auth = vi.hoisted(() => ({
+  user: undefined as
+    | {
+        value: null | { getIdToken: () => Promise<string> };
+      }
+    | undefined,
+}));
+
+vi.mock('../../composables/useAuth', async () => {
+  const { ref } = await import('vue');
+  auth.user = ref(null);
+
+  return {
+    useAuth: () => ({
+      user: auth.user,
+    }),
+  };
+});
+
+vi.mock('../../composables/useApi', () => api);
+
+enableAutoUnmount(afterEach);
+
+describe('IngestionUploadPanel', () => {
+  beforeEach(() => {
+    api.createIngestionJob.mockReset();
+    api.fetchConcertGenres.mockReset();
+    api.fetchIngestionJob.mockReset();
+    api.uploadIngestionImage.mockReset();
+
+    auth.user!.value = {
+      getIdToken: vi.fn().mockResolvedValue('firebase-token'),
+    };
+    api.fetchConcertGenres.mockResolvedValue({ genres: ['Electronic'] });
+    api.uploadIngestionImage.mockResolvedValue(buildUploadResult());
+    api.createIngestionJob.mockResolvedValue(buildJobResponse());
+    api.fetchIngestionJob.mockResolvedValue(buildJobResponse());
+  });
+
+  it('loads only API genres and includes a selected genre in the upload', async () => {
+    api.fetchConcertGenres.mockResolvedValue({ genres: ['Jazz', 'Funk'] });
+
+    const wrapper = mount(IngestionUploadPanel);
+    await flushPromises();
+
+    expect(api.fetchConcertGenres).toHaveBeenCalledWith();
+    expect(
+      wrapper.findAll('select option').map((option) => option.text()),
+    ).toEqual(['Optional genre', 'Jazz', 'Funk']);
+
+    await wrapper.get('select').setValue('Jazz');
+    await selectValidFile(wrapper);
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(api.uploadIngestionImage).toHaveBeenCalledWith(
+      'firebase-token',
+      expect.objectContaining({
+        genre: 'Jazz',
+      }),
+    );
+  });
+
+  it('keeps upload available and omits genre when the API returns no genres', async () => {
+    api.fetchConcertGenres.mockResolvedValue({ genres: [] });
+
+    const wrapper = mount(IngestionUploadPanel);
+    await flushPromises();
+    await selectValidFile(wrapper);
+
+    expect(wrapper.text()).toContain(
+      'No genres are available yet. You can still upload without one.',
+    );
+    expect(
+      wrapper.get<HTMLButtonElement>('button[type="submit"]').element.disabled,
+    ).toBe(false);
+
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(api.uploadIngestionImage).toHaveBeenCalledWith(
+      'firebase-token',
+      expect.any(Object),
+    );
+    expect(api.uploadIngestionImage.mock.calls[0]?.[1]).not.toHaveProperty(
+      'genre',
+    );
+  });
+
+  it('keeps upload available when genre loading fails', async () => {
+    api.fetchConcertGenres.mockRejectedValue(new Error('metadata unavailable'));
+
+    const wrapper = mount(IngestionUploadPanel);
+    await flushPromises();
+    await selectValidFile(wrapper);
+
+    expect(wrapper.text()).toContain(
+      'Genres are unavailable right now. You can still upload without one.',
+    );
+    expect(
+      wrapper.get<HTMLButtonElement>('button[type="submit"]').element.disabled,
+    ).toBe(false);
+
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(api.uploadIngestionImage).toHaveBeenCalledWith(
+      'firebase-token',
+      expect.any(Object),
+    );
+    expect(api.uploadIngestionImage.mock.calls[0]?.[1]).not.toHaveProperty(
+      'genre',
+    );
+  });
+});
+
+async function selectValidFile(wrapper: VueWrapper) {
+  const input = wrapper.get<HTMLInputElement>('input[type="file"]');
+  const file = new File(['poster'], 'poster.jpg', { type: 'image/jpeg' });
+  Object.defineProperty(input.element, 'files', {
+    configurable: true,
+    value: [file],
+  });
+  await input.trigger('change');
+}
+
+function buildUploadResult() {
+  return {
+    concertUploadId: 'upload-1',
+    bucket: 'test-bucket',
+    objectName: 'poster.jpg',
+    storageUri: 'gs://test-bucket/poster.jpg',
+    contentType: 'image/jpeg',
+    size: 6,
+    originalFilename: 'poster.jpg',
+    source: 'flyer_upload',
+    uploadedAt: '2026-07-26T16:00:00.000Z',
+  };
+}
+
+function buildJobResponse() {
+  return {
+    id: 'job-1',
+    status: 'needs_review',
+    stage: 'candidate_pending',
+    createdAt: '2026-07-26T16:00:00.000Z',
+    updatedAt: '2026-07-26T16:00:00.000Z',
+    concertUpload: {
+      id: 'upload-1',
+      storageUri: 'gs://test-bucket/poster.jpg',
+      objectName: 'poster.jpg',
+      bucket: 'test-bucket',
+      mimeType: 'image/jpeg',
+      originalFilename: 'poster.jpg',
+      source: 'flyer_upload',
+      size: 6,
+      uploadedByUid: 'uid-1',
+      createdAt: '2026-07-26T16:00:00.000Z',
+    },
+  };
+}

--- a/client/src/components/ingestion/IngestionUploadPanel.vue
+++ b/client/src/components/ingestion/IngestionUploadPanel.vue
@@ -58,6 +58,26 @@
         <input v-model="state" type="text" maxlength="2" placeholder="NC" />
       </label>
 
+      <label>
+        <span>Genre</span>
+        <select
+          v-model="genre"
+          :aria-describedby="genreHelpMessage ? 'genre-help' : undefined"
+        >
+          <option value="">Optional genre</option>
+          <option v-for="option in genres" :key="option" :value="option">
+            {{ option }}
+          </option>
+        </select>
+        <small
+          v-if="genreHelpMessage"
+          id="genre-help"
+          class="ingestion-panel__field-help"
+        >
+          {{ genreHelpMessage }}
+        </small>
+      </label>
+
       <p v-if="message" :class="messageClass">{{ message }}</p>
 
       <div class="ingestion-panel__actions">
@@ -91,6 +111,10 @@
           <dd>{{ uploadLocation }}</dd>
         </div>
         <div>
+          <dt>Genre</dt>
+          <dd>{{ uploadResult.genre ?? 'Not provided' }}</dd>
+        </div>
+        <div>
           <dt>Status</dt>
           <dd>{{ currentStatus }}</dd>
         </div>
@@ -108,10 +132,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { AxiosError } from 'axios';
 import {
   createIngestionJob,
+  fetchConcertGenres,
   fetchIngestionJob,
   type IngestionJobResponse,
   type IngestionUploadResult,
@@ -139,6 +164,9 @@ const fileInput = ref<HTMLInputElement | null>(null);
 const isDragActive = ref(false);
 const city = ref('');
 const state = ref('NC');
+const genre = ref('');
+const genres = ref<string[]>([]);
+const genreLoadState = ref<'loading' | 'loaded' | 'empty' | 'failed'>('loading');
 const message = ref('');
 const messageType = ref<'success' | 'error'>('success');
 const isSubmitting = ref(false);
@@ -176,6 +204,18 @@ const progressCopy = computed(() => {
 const uploadLocation = computed(() =>
   [uploadResult.value?.city, uploadResult.value?.state].filter(Boolean).join(', ') || 'Not provided',
 );
+const genreHelpMessage = computed(() => {
+  if (genreLoadState.value === 'loading') {
+    return 'Loading current genres…';
+  }
+  if (genreLoadState.value === 'failed') {
+    return 'Genres are unavailable right now. You can still upload without one.';
+  }
+  if (genreLoadState.value === 'empty') {
+    return 'No genres are available yet. You can still upload without one.';
+  }
+  return '';
+});
 const acceptedFileTypes = acceptedMimeTypes.join(',');
 const formattedFileSize = computed(() => {
   if (!selectedFile.value) {
@@ -191,6 +231,21 @@ const messageClass = computed(() =>
     ? 'ingestion-panel__message ingestion-panel__message--success'
     : 'ingestion-panel__message ingestion-panel__message--error',
 );
+
+const loadGenres = async () => {
+  try {
+    const response = await fetchConcertGenres();
+    genres.value = response.genres;
+    genreLoadState.value = genres.value.length ? 'loaded' : 'empty';
+  } catch {
+    genres.value = [];
+    genreLoadState.value = 'failed';
+  }
+};
+
+onMounted(() => {
+  void loadGenres();
+});
 
 const resetFileInput = () => {
   if (fileInput.value) {
@@ -302,6 +357,7 @@ const handleSubmit = async () => {
       file: selectedFile.value,
       city: city.value.trim() || undefined,
       state: state.value.trim().toUpperCase() || undefined,
+      ...(genre.value ? { genre: genre.value } : {}),
       source: 'flyer_upload',
     });
     job.value = await createIngestionJob(token, uploadResult.value.concertUploadId);
@@ -484,6 +540,12 @@ const handleSubmit = async () => {
 .ingestion-panel__form input::placeholder {
   color: #7a8378;
   opacity: 1;
+}
+
+.ingestion-panel__field-help {
+  color: var(--text-light);
+  font-size: 0.82rem;
+  line-height: 1.4;
 }
 
 .ingestion-panel__actions {

--- a/client/src/composables/useApi.ts
+++ b/client/src/composables/useApi.ts
@@ -62,6 +62,17 @@ export async function fetchConcerts(
   }
 }
 
+export interface ConcertGenresResponse {
+  genres: string[];
+}
+
+export async function fetchConcertGenres(): Promise<ConcertGenresResponse> {
+  const response = await apiClient.get<ConcertGenresResponse>(
+    '/concerts/meta/genres',
+  );
+  return response.data;
+}
+
 export async function fetchUserConcerts(
   token: string,
   params?: {
@@ -136,6 +147,7 @@ export interface IngestionUploadResult {
   originalFilename: string;
   city?: string;
   state?: string;
+  genre?: string;
   source: string;
   uploadedByUserId?: number;
   uploadedAt: string;
@@ -161,6 +173,7 @@ export interface IngestionJobResponse {
     originalFilename: string;
     city?: string;
     state?: string;
+    genre?: string;
     source: string;
     size: number;
     uploadedByUid: string;
@@ -196,6 +209,7 @@ export async function uploadIngestionImage(
     file: File;
     city?: string;
     state?: string;
+    genre?: string;
     source?: string;
   },
 ) {
@@ -207,6 +221,10 @@ export async function uploadIngestionImage(
     }
     if (payload.state) {
       formData.append('state', payload.state);
+    }
+    const genre = payload.genre?.trim();
+    if (genre) {
+      formData.append('genre', genre);
     }
     if (payload.source) {
       formData.append('source', payload.source);
@@ -365,6 +383,7 @@ export interface AdminConcertUploadListItem {
   size: number;
   city?: string;
   state?: string;
+  genre?: string;
   source: string;
   uploadedByUid: string;
   uploadedByUserId?: number;

--- a/src/ingestion/dto/create-ingestion-upload.dto.ts
+++ b/src/ingestion/dto/create-ingestion-upload.dto.ts
@@ -23,6 +23,16 @@ export class CreateIngestionUploadDto {
   state?: string;
 
   @ApiPropertyOptional({
+    description: 'User-selected genre hint for the uploaded concert asset.',
+    maxLength: 120,
+    example: 'Electronic',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  genre?: string;
+
+  @ApiPropertyOptional({
     description: 'Upload source classification.',
     enum: ['flyer_upload', 'manual_upload', 'partner_upload'],
     example: 'flyer_upload',

--- a/src/ingestion/dto/ingestion-response.dto.ts
+++ b/src/ingestion/dto/ingestion-response.dto.ts
@@ -34,6 +34,9 @@ export class IngestionUploadResponseDto {
   @ApiPropertyOptional({ example: 'NC' })
   state?: string;
 
+  @ApiPropertyOptional({ example: 'Electronic' })
+  genre?: string;
+
   @ApiProperty({ example: 'flyer_upload' })
   source: string;
 
@@ -76,6 +79,9 @@ export class AdminConcertUploadResponseDto {
 
   @ApiPropertyOptional({ example: 'NC' })
   state?: string;
+
+  @ApiPropertyOptional({ example: 'Electronic' })
+  genre?: string;
 
   @ApiProperty({ example: 'flyer_upload' })
   source: string;

--- a/src/ingestion/entities/concert-upload.entity.ts
+++ b/src/ingestion/entities/concert-upload.entity.ts
@@ -39,6 +39,9 @@ export class ConcertUpload {
   @Column({ nullable: true })
   state?: string;
 
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  genre?: string | null;
+
   @Column({ default: 'flyer_upload' })
   source: string;
 

--- a/src/ingestion/ingestion.controller.spec.ts
+++ b/src/ingestion/ingestion.controller.spec.ts
@@ -28,14 +28,24 @@ describe('IngestionController', () => {
 
     await controller.uploadImage(
       { file: [file] },
-      { city: 'raleigh', state: 'NC', source: 'flyer_upload' },
+      {
+        city: 'raleigh',
+        state: 'NC',
+        genre: '  Electronic  ',
+        source: 'flyer_upload',
+      },
       { uid: 'uid-1' } as any,
     );
 
     expect(userService.syncFromToken).toHaveBeenCalledWith({ uid: 'uid-1' });
     expect(ingestionService.uploadImage).toHaveBeenCalledWith(
       file,
-      { city: 'raleigh', state: 'NC', source: 'flyer_upload' },
+      {
+        city: 'raleigh',
+        state: 'NC',
+        genre: '  Electronic  ',
+        source: 'flyer_upload',
+      },
       'uid-1',
       3,
     );

--- a/src/ingestion/ingestion.controller.ts
+++ b/src/ingestion/ingestion.controller.ts
@@ -57,6 +57,7 @@ export class IngestionController {
         image: { type: 'string', format: 'binary' },
         city: { type: 'string', example: 'Charlotte' },
         state: { type: 'string', example: 'NC' },
+        genre: { type: 'string', maxLength: 120, example: 'Electronic' },
         source: {
           type: 'string',
           enum: ['flyer_upload', 'manual_upload', 'partner_upload'],

--- a/src/ingestion/ingestion.service.spec.ts
+++ b/src/ingestion/ingestion.service.spec.ts
@@ -99,7 +99,7 @@ describe('IngestionService', () => {
     service = module.get<IngestionService>(IngestionService);
   });
 
-  it('should persist the upload metadata with the simplified dto shape', async () => {
+  it('should trim, persist, copy, and return a selected upload genre', async () => {
     const file = {
       originalname: 'poster.jpg',
       mimetype: 'image/jpeg',
@@ -113,10 +113,9 @@ describe('IngestionService', () => {
       ...concertUploadRepository.create.mock.calls[0]?.[0],
     });
 
+    const objectSave = jest.fn().mockResolvedValue(undefined);
     const bucketMock = {
-      file: jest.fn().mockReturnValue({
-        save: jest.fn().mockResolvedValue(undefined),
-      }),
+      file: jest.fn().mockReturnValue({ save: objectSave }),
     };
 
     Object.defineProperty(service as object, 'storage', {
@@ -125,7 +124,12 @@ describe('IngestionService', () => {
 
     const result = await service.uploadImage(
       file,
-      { city: 'wilmington', state: 'NC', source: 'flyer_upload' },
+      {
+        city: 'wilmington',
+        state: 'NC',
+        genre: '  Electronic  ',
+        source: 'flyer_upload',
+      },
       'uid-1',
       3,
     );
@@ -134,17 +138,67 @@ describe('IngestionService', () => {
       expect.objectContaining({
         city: 'wilmington',
         state: 'NC',
+        genre: 'Electronic',
         source: 'flyer_upload',
         uploadedByUid: 'uid-1',
         uploadedByUserId: 3,
       }),
     );
+    expect(objectSave).toHaveBeenCalledWith(
+      file.buffer,
+      expect.objectContaining({
+        metadata: {
+          metadata: expect.objectContaining({
+            genre: 'Electronic',
+          }),
+        },
+      }),
+    );
     expect(result.concertUploadId).toBe('asset-1');
     expect(result.city).toBe('wilmington');
     expect(result.state).toBe('NC');
+    expect(result.genre).toBe('Electronic');
     expect(result.source).toBe('flyer_upload');
     expect(result.uploadedByUserId).toBe(3);
   });
+
+  it.each([undefined, '   '])(
+    'should keep uploads working without a non-empty genre (%p)',
+    async (genre) => {
+      const file = {
+        originalname: 'poster.jpg',
+        mimetype: 'image/jpeg',
+        buffer: Buffer.from('image'),
+        size: 5,
+      } as UploadableFile;
+      const objectSave = jest.fn().mockResolvedValue(undefined);
+
+      concertUploadRepository.create.mockImplementation((value) => value);
+      concertUploadRepository.save.mockResolvedValue({
+        id: 'asset-1',
+      });
+      Object.defineProperty(service as object, 'storage', {
+        value: {
+          bucket: jest.fn().mockReturnValue({
+            file: jest.fn().mockReturnValue({ save: objectSave }),
+          }),
+        },
+      });
+
+      const result = await service.uploadImage(
+        file,
+        { genre },
+        'uid-1',
+      );
+
+      expect(concertUploadRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ genre: undefined }),
+      );
+      const saveOptions = objectSave.mock.calls[0]?.[1];
+      expect(saveOptions.metadata.metadata).not.toHaveProperty('genre');
+      expect(result.genre).toBeUndefined();
+    },
+  );
 
   it('should create a queued job for an owned concert upload', async () => {
     const concertUpload = {
@@ -156,6 +210,7 @@ describe('IngestionService', () => {
       originalFilename: 'poster.jpg',
       city: 'wilmington',
       state: 'NC',
+      genre: 'Electronic',
       source: 'flyer_upload',
       size: 12,
       uploadedByUid: 'uid-1',
@@ -193,6 +248,7 @@ describe('IngestionService', () => {
     );
     expect(result.id).toBe('job-1');
     expect(result.concertUpload.id).toBe('asset-1');
+    expect(result.concertUpload.genre).toBe('Electronic');
     expect(result.concertUpload.uploadedByUserId).toBe(3);
   });
 
@@ -207,6 +263,7 @@ describe('IngestionService', () => {
       originalFilename: 'poster.jpg',
       city: 'wilmington',
       state: 'NC',
+      genre: 'Electronic',
       source: 'flyer_upload',
       size: 12,
       uploadedByUid: 'uid-1',
@@ -220,6 +277,7 @@ describe('IngestionService', () => {
       where: { id: 'asset-1', uploadedByUid: 'uid-1' },
     });
     expect(result.concertUploadId).toBe('asset-1');
+    expect(result.genre).toBe('Electronic');
     expect(result.uploadedAt).toBe(createdAt.toISOString());
   });
 
@@ -240,6 +298,7 @@ describe('IngestionService', () => {
         originalFilename: 'poster.jpg',
         city: 'raleigh',
         state: 'NC',
+        genre: 'Electronic',
         source: 'flyer_upload',
         size: 12,
         uploadedByUid: 'uid-1',
@@ -289,6 +348,7 @@ describe('IngestionService', () => {
         },
       );
       expect(result.reviewStatus).toBe(reviewStatus);
+      expect(result.genre).toBe('Electronic');
       expect(result.reviewedByUserEmail).toBe('admin@example.local');
       if (reviewStatus === 'approved') {
         expect(concertRepository.save).toHaveBeenCalledWith(

--- a/src/ingestion/ingestion.service.ts
+++ b/src/ingestion/ingestion.service.ts
@@ -213,6 +213,7 @@ export class IngestionService {
 
     const uploadedAt = new Date().toISOString();
     const normalizedSource = dto.source ?? 'flyer_upload';
+    const normalizedGenre = dto.genre?.trim() || undefined;
     const objectName = this.buildObjectName(file.originalname, uid, uploadedAt);
     const bucket = this.storage.bucket(this.bucketName);
     const object = bucket.file(objectName);
@@ -228,6 +229,7 @@ export class IngestionService {
             uploadedByUid: uid,
             city: dto.city ?? '',
             state: dto.state ?? '',
+            ...(normalizedGenre ? { genre: normalizedGenre } : {}),
             source: normalizedSource,
             uploadedByUserId: uploadedByUserId?.toString() ?? '',
             originalFilename: file.originalname,
@@ -251,6 +253,7 @@ export class IngestionService {
         originalFilename: file.originalname,
         city: dto.city,
         state: dto.state,
+        genre: normalizedGenre,
         source: normalizedSource,
         reviewStatus: 'submitted',
         uploadedByUid: uid,
@@ -269,6 +272,7 @@ export class IngestionService {
       originalFilename: file.originalname,
       city: dto.city,
       state: dto.state,
+      genre: normalizedGenre,
       source: normalizedSource,
       uploadedByUserId,
       uploadedAt,
@@ -443,6 +447,7 @@ export class IngestionService {
       size: Number(upload.size),
       city: upload.city,
       state: upload.state,
+      genre: upload.genre ?? undefined,
       source: upload.source,
       uploadedByUid: upload.uploadedByUid,
       uploadedByUserId: upload.uploadedByUserId,
@@ -594,6 +599,7 @@ export class IngestionService {
         originalFilename: concertUpload.originalFilename,
         city: concertUpload.city,
         state: concertUpload.state,
+        genre: concertUpload.genre ?? undefined,
         source: concertUpload.source,
         size: Number(concertUpload.size),
         uploadedByUid: concertUpload.uploadedByUid,
@@ -616,6 +622,7 @@ export class IngestionService {
       originalFilename: concertUpload.originalFilename,
       city: concertUpload.city,
       state: concertUpload.state,
+      genre: concertUpload.genre ?? undefined,
       source: concertUpload.source,
       uploadedByUserId: concertUpload.uploadedByUserId,
       uploadedAt: concertUpload.createdAt.toISOString(),

--- a/src/ingestion/interfaces/admin-concert-upload.interface.ts
+++ b/src/ingestion/interfaces/admin-concert-upload.interface.ts
@@ -10,6 +10,7 @@ export interface AdminConcertUploadListItem {
   size: number;
   city?: string;
   state?: string;
+  genre?: string;
   source: string;
   uploadedByUid: string;
   uploadedByUserId?: number;

--- a/src/ingestion/interfaces/ingestion-job-response.interface.ts
+++ b/src/ingestion/interfaces/ingestion-job-response.interface.ts
@@ -18,6 +18,7 @@ export interface IngestionJobResponse {
     originalFilename: string;
     city?: string;
     state?: string;
+    genre?: string;
     source: string;
     size: number;
     uploadedByUid: string;

--- a/src/ingestion/interfaces/ingestion-upload-result.interface.ts
+++ b/src/ingestion/interfaces/ingestion-upload-result.interface.ts
@@ -8,6 +8,7 @@ export interface IngestionUploadResult {
   originalFilename: string;
   city?: string;
   state?: string;
+  genre?: string;
   source: string;
   uploadedByUserId?: number;
   uploadedAt: string;

--- a/src/migrations/1760000011000-AddGenreToConcertUploads.ts
+++ b/src/migrations/1760000011000-AddGenreToConcertUploads.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGenreToConcertUploads1760000011000 implements MigrationInterface {
+  name = 'AddGenreToConcertUploads1760000011000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "concert_uploads"
+      ADD COLUMN IF NOT EXISTS "genre" varchar(120)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "concert_uploads"
+      DROP COLUMN IF EXISTS "genre"
+    `);
+  }
+}


### PR DESCRIPTION
## Summary

- add an optional Genre dropdown to the poster upload panel
- load genre options from the public `GET /concerts/meta/genres` endpoint
- submit genre only when selected
- trim, persist, and return the optional genre through upload, ingestion-job, and admin response contracts
- add a reversible nullable migration for `concert_uploads.genre`
- add focused backend and client tests

Closes #58.

## Validation

- `npm test -- --runInBand ingestion` — 3 suites, 21 tests passed
- `npm run build` — passed
- `npm test --prefix client` — 3 files, 7 tests passed
- `npm run build --prefix client` — passed
- repository smoke script — passed
- `git diff --check` — passed
- API, client, Swagger, OpenAPI, Concerts, and genre metadata endpoints returned HTTP 200 locally

## Manual evidence

- Jerry Days poster upload persisted `Live Music`
- Oak City Test Signal poster upload persisted `Electronic`
- both uploads completed review and linked to admin-approved concerts

## Manual test path

1. Sign in and open the Concerts page.
2. Locate the poster upload panel.
3. Confirm the optional Genre dropdown is populated by `/concerts/meta/genres`.
4. Upload a poster with a selected genre and confirm the returned upload/job data includes it.
5. Upload a poster without selecting a genre and confirm the existing upload flow is unchanged.